### PR TITLE
Define basic models for metrics.

### DIFF
--- a/app/models/MetricsData.scala
+++ b/app/models/MetricsData.scala
@@ -1,0 +1,31 @@
+package models
+
+sealed trait PublishingSystem
+case object Composer extends PublishingSystem
+case object InCopy extends PublishingSystem
+
+case class Metrics (
+    id: String,
+    contentCreated: Long,
+    composerId: Option[String],
+    storyBundleId: Option[String],
+    firstSeenInWorkflow: Option[Long],
+    firstSeenInComposer: Option[Long],
+    firstSeenInInCopy: Option[Long],
+    inWorkflow: Boolean,
+    inNewspaper: Boolean,
+    onlinePublicationTime: Option[Long],
+    commissioningDesk: Option[String],
+    section: Option[String],
+    desk: Option[String],
+    startingSystem: PublishingSystem,
+    forkTime: Option[Long])
+
+case class InCopyData (
+   storyBundleId: String,
+   desk: String,
+   section: String)
+
+case class ComposerData (composerId: String)
+
+


### PR DESCRIPTION
Keen to get some feedback on some basic metrics models
`InCopyData` and `ComposerData` are the models of the data sent from the incopy and composer systems. `Metrics` is what I think should be stored in the Dynamo database.