### PR TITLE
Fix deploy failures.

### DIFF
--- a/cloudformation/EditorialProductionMetrics.yml
+++ b/cloudformation/EditorialProductionMetrics.yml
@@ -76,9 +76,6 @@ Mappings:
     IpRange:
       CODE: 77.91.248.0/21
       PROD: 0.0.0.0/0
-    DesiredCapacity:
-      CODE: 1
-      PROD: 1
     MaxSize:
       CODE: 2
       PROD: 2
@@ -157,7 +154,6 @@ Resources:
     Properties:
       VPCZoneIdentifier: !Ref PrivateSubnets
       Cooldown: '300'
-      DesiredCapacity: !FindInMap [ Config, DesiredCapacity, !Ref Stage ]
       MaxSize: !FindInMap [ Config, MaxSize, !Ref Stage ]
       MinSize: !FindInMap [ Config, MinSize, !Ref Stage ]
       LoadBalancerNames:

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -6,6 +6,8 @@ deployments:
     type: autoscaling
     parameters:
       bucket: composer-dist
+    dependencies:
+    - editorial-production-metrics-ami-update
   editorial-production-metrics-ami-update:
     type: ami-cloudformation-parameter
     app: editorial-production-metrics


### PR DESCRIPTION
Riffraff was failing when there was a new ami update due to the lack of a dependancy.

Also don't need to specify a desired capacity.