### PR TITLE
Allow lowercase for originating system param

### DIFF
--- a/app/models/db/Metrics.scala
+++ b/app/models/db/Metrics.scala
@@ -1,6 +1,6 @@
 package models.db
 
-import enumeratum.EnumEntry.Snakecase
+import enumeratum.EnumEntry.Lowercase
 import enumeratum.{CirceEnum, Enum, EnumEntry}
 import io.circe._
 import io.circe.generic.semiauto._
@@ -26,7 +26,7 @@ object Metric {
   implicit val metricEncoder: Encoder[Metric] = deriveEncoder
 }
 
-sealed trait OriginatingSystem extends EnumEntry with Snakecase
+sealed trait OriginatingSystem extends EnumEntry with Lowercase
 case object OriginatingSystem extends Enum[OriginatingSystem] with CirceEnum[OriginatingSystem] {
   case object Composer extends OriginatingSystem
   case object InCopy extends OriginatingSystem

--- a/app/models/db/Metrics.scala
+++ b/app/models/db/Metrics.scala
@@ -1,5 +1,6 @@
 package models.db
 
+import enumeratum.EnumEntry.Snakecase
 import enumeratum.{CirceEnum, Enum, EnumEntry}
 import io.circe._
 import io.circe.generic.semiauto._
@@ -25,7 +26,7 @@ object Metric {
   implicit val metricEncoder: Encoder[Metric] = deriveEncoder
 }
 
-sealed trait OriginatingSystem extends EnumEntry
+sealed trait OriginatingSystem extends EnumEntry with Snakecase
 case object OriginatingSystem extends Enum[OriginatingSystem] with CirceEnum[OriginatingSystem] {
   case object Composer extends OriginatingSystem
   case object InCopy extends OriginatingSystem

--- a/conf/routes
+++ b/conf/routes
@@ -1,11 +1,11 @@
-GET     /                           controllers.App.index
+GET     /                                 controllers.App.index
 
-GET     /api/startingSystem/:system controllers.App.getStartedIn(system: String)
+GET     /api/originatingSystem/:system    controllers.App.getStartedIn(system: String)
 
-GET     /healthcheck                controllers.Healthcheck.healthcheck
+GET     /healthcheck                      controllers.Healthcheck.healthcheck
 
-GET     /oauthCallback              controllers.Login.oauthCallback
-GET     /reauth                     controllers.Login.reauth
+GET     /oauthCallback                    controllers.Login.oauthCallback
+GET     /reauth                           controllers.Login.reauth
 
 # Map static resources from the /public folder to the /assets URL path
-GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)
+GET     /assets/*file                     controllers.Assets.versioned(path="/public", file: Asset)


### PR DESCRIPTION
A small bug was only allowing calls like: `/api/originatingSystem/Composer`. We'd like `composer` to be lowercase in the url.