### PR TITLE
Add unique DEV identifier for the kinesis stream.

### DIFF
--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -29,4 +29,7 @@ class Config(config: Configuration) extends AwsInstanceTags {
 
   val publishingMetricsKinesisStream = getConfigString("kinesis.publishingMetricsStream")
 
+//  This is for uniquely identifying the kinesis application when running the app locally on multiple DEV machines
+  val devIdentifier = if(stage == "DEV") getConfigString("user") else ""
+
 }

--- a/app/kinesis/KinesisStreamReader.scala
+++ b/app/kinesis/KinesisStreamReader.scala
@@ -22,7 +22,7 @@ trait KinesisStreamReader {
    * about how much of the stream we have consumed. The application
    * name should be unique for each stream and be less than 255
    * characters. */
-  lazy val applicationName: String = s"${streamName}_editorial_production_metrics_$stage"
+  lazy val applicationName: String = s"${streamName}_editorial_production_metrics_${stage}${config.devIdentifier}"
 
   /* only applies when there are no checkpoints */
   val initialPosition = InitialPositionInStream.LATEST

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -7,3 +7,5 @@ play.crypto.secret="Replace me, please!"
 panda.system="editorial-production-metrics"
 
 play.evolutions.autoApply=true
+
+user = ${?USER}


### PR DESCRIPTION
When defining the kinesis application name currently the pattern is `s"${streamName}_editorial_production_metrics_$stage"`. This means that the dynamoDB that keeps track of stream consumption is written to by all instances of the app running in DEV mode so items can appear to go missing when testing.

Adding a DEV identifier which is set to `""` when not in DEV mode.