### PR TITLE
Trigger to get creation date.

### DIFF
--- a/conf/evolutions/default/5.sql
+++ b/conf/evolutions/default/5.sql
@@ -1,0 +1,22 @@
+# --- !Ups
+
+CREATE OR REPLACE FUNCTION set_creation_date() RETURNS TRIGGER AS
+$BODY$
+BEGIN
+    UPDATE metrics SET creation_date = date_trunc('day', NEW.creation_time) WHERE id = NEW.id;;
+    RETURN NEW;;
+END;;
+$BODY$
+LANGUAGE plpgsql;
+
+CREATE TRIGGER set_creation_date_trigger
+     AFTER UPDATE OR INSERT ON metrics
+     FOR EACH ROW
+     WHEN (pg_trigger_depth() < 1)
+     EXECUTE PROCEDURE set_creation_date();
+
+# --- !Downs
+
+DROP TRIGGER IF EXISTS set_creation_date_trigger ON metrics;
+
+DROP FUNCTION IF EXISTS set_creation_date();


### PR DESCRIPTION
We want to be able to group articles by day but still keep the exact time of creation. Using a trigger to create a column that stores this information so we don't need to do this in the scala api.