### PR TITLE
Ignore logs from the kinesis worker.

### DIFF
--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -23,6 +23,7 @@
 
     <logger name="play" level="INFO" />
     <logger name="application" level="INFO" />
+    <logger name="com.amazonaws.services.kinesis.clientlibrary.lib.worker.Worker" level="OFF" />
 
     <root level="INFO">
         <appender-ref ref="FILE" />


### PR DESCRIPTION
`com.amazonaws.services.kinesis.clientlibrary.lib.worker.Worker` logs:
`Current stream shard assignments: shardId-000000000000`
and 
`Sleeping ...`
about once a minute. This makes the logs very noisy and debugging more difficult. This change filters out these logs.