### PR TITLE
Evolution: Make in_newspaper and round_trip not null

### DIFF
--- a/conf/evolutions/default/8.sql
+++ b/conf/evolutions/default/8.sql
@@ -1,0 +1,9 @@
+# --- !Ups
+
+ALTER TABLE metrics ALTER COLUMN in_newspaper SET NOT NULL;
+ALTER TABLE metrics ALTER COLUMN round_trip SET NOT NULL;
+
+# --- !Downs
+
+ALTER TABLE metrics ALTER COLUMN in_newspaper DROP NOT NULL;
+ALTER TABLE metrics ALTER COLUMN round_trip DROP NOT NULL;


### PR DESCRIPTION
They have a default value, we should use that instead of setting them to `null`.