### PR TITLE
Fix routing when no query params are present

### DIFF
--- a/public/js/redux/chartsRedux.js
+++ b/public/js/redux/chartsRedux.js
@@ -37,8 +37,8 @@ const chartsRedux = State({
     updateComposerVsIncopy(state, { chartData, startDate, endDate }) {
         const { composerResponse, inCopyResponse } = chartData;
         const range = endDate.diff(startDate, 'days');
-        const composerData = composerResponse.data.length <= range ?  fillMissingDates(startDate, endDate, composerResponse.data).sort(compareDates) : composerResponse.data;
-        const inCopyData = inCopyResponse.data.length <= range ?  fillMissingDates(startDate, endDate, inCopyResponse.data).sort(compareDates) : inCopyResponse.data;
+        const composerData = composerResponse.data.length <= range ?  fillMissingDates(startDate, endDate, composerResponse.data).sort(compareDates) : composerResponse.data.sort(compareDates);
+        const inCopyData = inCopyResponse.data.length <= range ?  fillMissingDates(startDate, endDate, inCopyResponse.data).sort(compareDates) : inCopyResponse.data.sort(compareDates);
         const composerVsInCopyData = [{ data: composerData }, { data: inCopyData }];
         const seriesWithLabels = composerVsInCopyData.map(series => {
             return { 

--- a/public/js/services/routingMiddleware.js
+++ b/public/js/services/routingMiddleware.js
@@ -10,13 +10,13 @@ export const updateUrlFromStateChangeMiddleware = ({ dispatch, getState }) => (n
     const newState = getState();
     // this formatting is needed as the dates in the state are moment objects, but need to be strings in the url
     const newStateFormattedFilters = { ...newState.filterVals,  startDate: newState.filterVals.startDate.format(), endDate: newState.filterVals.endDate.format() };
-    
+
     if (!_isEqual(prevState.filterVals, newState.filterVals)) {
         const location = newState.routing.location;
         const paramString = `?${objectToParamString(newStateFormattedFilters)}`;
 
         if (location && paramString !== location.search) {
-            const newLocation = { ...location, search: paramString || ''}
+            const newLocation = { ...location, search: paramString || ''};
             const updateAction = replace(newLocation);
             dispatch(updateAction);
         }
@@ -28,10 +28,12 @@ export const updateUrlFromStateChangeMiddleware = ({ dispatch, getState }) => (n
 export const updateStateFromUrlChangeMiddleware = ({ _, getState }) => (next) => (action) => {
     next(action);
     const newState = getState();
+
     if (action.type === '@@router/LOCATION_CHANGE') {
         const filterObj = paramStringToObject(newState.routing.location.search);
-        filterObj['startDate'] = moment(filterObj['startDate']).subtract(7,'d').utc().startOf('day');
+        filterObj['startDate'] = !newState.routing.location.search ? moment(filterObj['startDate']).subtract(7,'d').utc().startOf('day') : moment(filterObj['startDate']).utc().startOf('day');
         filterObj['endDate'] = moment(filterObj['endDate']).utc().endOf('day');
+
         if (!_isEqual(filterObj, newState.filterVals)) {
             Actions.filterDesk(filterObj);
         }


### PR DESCRIPTION
Sharing urls now behaves as expected: with no query params, the initial time range is today-one week ago, and the url will be updated to reflect this. If query params are present, the time range will be the one suggested by the query. 

This also fixes the incorrect visualisation of the graph by ordering the dates in the response chronologically.