### PR TITLE
New fork endpoint and refactoring

### DIFF
--- a/app/controllers/App.scala
+++ b/app/controllers/App.scala
@@ -82,11 +82,11 @@ class App(val wsClient: WSClient, val config: Config, val db: MetricsDB) extends
     }
   }
 
-  def getForks() = APIAuthAction { req =>
+  def getForks() = Action { _ =>
     APIResponse {
       for {
-        metric <- db.getGroupedByDayMetrics(MetricsFilters(req.queryString))
-      } yield metric
+        forks <- db.getForks
+      } yield forks
     }
   }
 }

--- a/app/controllers/App.scala
+++ b/app/controllers/App.scala
@@ -80,4 +80,12 @@ class App(val wsClient: WSClient, val config: Config, val db: MetricsDB) extends
       } yield result
     }
   }
+
+  def getForks(inWorkflow: Boolean) = APIAuthAction { req =>
+    APIResponse {
+      for {
+        metric <- db.getGroupedByDayMetrics(MetricsFilters(req.queryString).copy(inWorkflow = Some(inWorkflow)))
+      } yield metric
+    }
+  }
 }

--- a/app/controllers/App.scala
+++ b/app/controllers/App.scala
@@ -65,7 +65,8 @@ class App(val wsClient: WSClient, val config: Config, val db: MetricsDB) extends
         for {
           bodyString <- extractRequestBody(req.body.asJson.map(_.toString))
           metricOpt <- extractFromString[MetricOpt](bodyString)
-          metric <- db.updateOrInsert(db.getPublishingMetricsWithComposerId(metricOpt.composerId), metricOpt)
+          metricFromDb <- db.getPublishingMetricsWithComposerId(metricOpt.composerId)
+          metric <- db.updateOrInsert(metricFromDb, metricOpt)
         } yield metric
       }
     }
@@ -81,10 +82,10 @@ class App(val wsClient: WSClient, val config: Config, val db: MetricsDB) extends
     }
   }
 
-  def getForks(inWorkflow: Boolean) = APIAuthAction { req =>
+  def getForks() = APIAuthAction { req =>
     APIResponse {
       for {
-        metric <- db.getGroupedByDayMetrics(MetricsFilters(req.queryString).copy(inWorkflow = Some(inWorkflow)))
+        metric <- db.getGroupedByDayMetrics(MetricsFilters(req.queryString))
       } yield metric
     }
   }

--- a/app/controllers/App.scala
+++ b/app/controllers/App.scala
@@ -84,9 +84,7 @@ class App(val wsClient: WSClient, val config: Config, val db: MetricsDB) extends
 
   def getForks() = APIAuthAction { _ =>
     APIResponse {
-      for {
-        forks <- db.getForks
-      } yield forks
+      db.getForks
     }
   }
 }

--- a/app/controllers/App.scala
+++ b/app/controllers/App.scala
@@ -82,7 +82,7 @@ class App(val wsClient: WSClient, val config: Config, val db: MetricsDB) extends
     }
   }
 
-  def getForks() = Action { _ =>
+  def getForks() = APIAuthAction { _ =>
     APIResponse {
       for {
         forks <- db.getForks

--- a/app/database/MetricsDB.scala
+++ b/app/database/MetricsDB.scala
@@ -45,7 +45,9 @@ class MetricsDB(val db: Database) {
       upsertPublishingMetric(Metric(metricOpt))
   }
 
-  def getForks: Seq[Fork] = await(db.run(forksTable.result))
+  def getForks: Either[ProductionMetricsError, List[ForkResponse]] = await {
+    db.run(forksTable.map(_.time).result).map { dateTimes => dateTimes.map(dt => ForkResponse(dt.withTimeAtStartOfDay(), dt)) }
+  }
   def insertFork(fork: Fork): Either[ProductionMetricsError, Int] = await {
     db.run(forksTable += fork).map(Right(_)).recover { case _ => Left(UnexpectedDbExceptionError)}
   }

--- a/app/database/MetricsDB.scala
+++ b/app/database/MetricsDB.scala
@@ -45,8 +45,8 @@ class MetricsDB(val db: Database) {
 
   def getForks: Either[ProductionMetricsError, List[ForkResponse]] =
     awaitWithTransformation(db.run(forksTable.map(f => (f.time, f.timeUntilFork)).result)){ dbResult =>
-      dbResult.map {
-        case (date, timeOpt) => ForkResponse(date, timeOpt.get)
+      dbResult.flatMap {
+        case (date, timeOpt) => timeOpt.fold(None: Option[ForkResponse])(time => Some(ForkResponse(date, time)))
       }.toList
   }
   def insertFork(fork: Fork): Either[ProductionMetricsError, Int] = await(db.run(forksTable += fork))

--- a/app/database/MetricsDB.scala
+++ b/app/database/MetricsDB.scala
@@ -10,26 +10,24 @@ import play.api.Logger
 import slick.jdbc.PostgresProfile.api._
 import util.AsyncHelpers._
 
-import scala.concurrent.ExecutionContext.Implicits.global
-
 class MetricsDB(val db: Database) {
 
   private val dateTrunc: (Rep[String], Rep[DateTime]) => Rep[DateTime] =
     SimpleFunction.binary[String, DateTime, DateTime]("date_trunc")
 
-  def getComposerMetrics: Seq[ComposerMetric] = await(db.run(composerMetricsTable.result))
-  def insertComposerMetric(metric: ComposerMetric): Int = await(db.run(composerMetricsTable += metric))
+  def getComposerMetrics: Either[ProductionMetricsError, Seq[ComposerMetric]] = await(db.run(composerMetricsTable.result))
+  def insertComposerMetric(metric: ComposerMetric): Either[ProductionMetricsError, Int] = await(db.run(composerMetricsTable += metric))
 
-  def getInCopyMetrics: Seq[InCopyMetric] = await(db.run(inCopyMetricsTable.result))
-  def insertInCopyMetric(metric: InCopyMetric): Int = await(db.run(inCopyMetricsTable += metric))
+  def getInCopyMetrics: Either[ProductionMetricsError, Seq[InCopyMetric]] = await(db.run(inCopyMetricsTable.result))
+  def insertInCopyMetric(metric: InCopyMetric): Either[ProductionMetricsError, Int] = await(db.run(inCopyMetricsTable += metric))
 
-  def getPublishingMetrics: Seq[Metric] = await(db.run(metricsTable.result))
-  def insertPublishingMetric(metric: Metric): Int = await(db.run(metricsTable += metric))
+  def getPublishingMetrics: Either[ProductionMetricsError, Seq[Metric]] = await(db.run(metricsTable.result))
+  def insertPublishingMetric(metric: Metric): Either[ProductionMetricsError, Int] = await(db.run(metricsTable += metric))
   def upsertPublishingMetric(metric: Metric): Either[ProductionMetricsError, Metric] = {
-    val result: Int = await(db.run(metricsTable.insertOrUpdate(metric)))
-    if (result == 0) Left(UnexpectedDbExceptionError) else Right(metric)
+    val result: Either[ProductionMetricsError, Int] = await(db.run(metricsTable.insertOrUpdate(metric)))
+    if (result.isLeft) Left(UnexpectedDbExceptionError) else Right(metric)
   }
-  def getPublishingMetricsWithComposerId(composerId: Option[String]): Option[Metric] =
+  def getPublishingMetricsWithComposerId(composerId: Option[String]): Either[ProductionMetricsError, Option[Metric]] =
     await(db.run(metricsTable.filter(_.composerId === composerId).result.headOption))
 
   def updateOrInsert(metric: Option[Metric], metricOpt: MetricOpt): Either[ProductionMetricsError, Metric] = metric match {
@@ -45,20 +43,21 @@ class MetricsDB(val db: Database) {
       upsertPublishingMetric(Metric(metricOpt))
   }
 
-  def getForks: Either[ProductionMetricsError, List[ForkResponse]] = await {
-    db.run(forksTable.map(_.time).result).map { dateTimes => dateTimes.map(dt => ForkResponse(dt.withTimeAtStartOfDay(), dt)) }
+  def getForks: Either[ProductionMetricsError, List[ForkResponse]] =
+    awaitWithTransformation(db.run(forksTable.map(f => (f.time, f.timeUntilFork)).result)){ dbResult =>
+      dbResult.map {
+        case (date, timeOpt) => ForkResponse(date, timeOpt.get)
+      }.toList
   }
-  def insertFork(fork: Fork): Either[ProductionMetricsError, Int] = await {
-    db.run(forksTable += fork).map(Right(_)).recover { case _ => Left(UnexpectedDbExceptionError)}
-  }
+  def insertFork(fork: Fork): Either[ProductionMetricsError, Int] = await(db.run(forksTable += fork))
 
   // This needs to return the data grouped by day. For this we've defined dateTrunc to tell Slick
   // to "import" the date_trunc function from postgresql
-  def getGroupedByDayMetrics(implicit filters: MetricsFilters): Either[ProductionMetricsError, List[CountResponse]] = await {
-    db.run(metricsTable.filter(MetricsFilters.metricFilters).map(m => (m.id, dateTrunc("day", m.creationTime))).groupBy(_._2).map {
-      case (date, metric) => (date, metric.size)
-    }.result).map { result: Seq[(DateTime, Int)] =>
-      Right(result.map(pair => CountResponse(new DateTime(pair._1), pair._2)).toList)
-    }.recover { case _ => Left(UnexpectedDbExceptionError) }
-  }
+  def getGroupedByDayMetrics(implicit filters: MetricsFilters): Either[ProductionMetricsError, List[CountResponse]] =
+    awaitWithTransformation(db.run(metricsTable.filter(MetricsFilters.metricFilters).map(m => (m.id, dateTrunc("day", m.creationTime)))
+      .groupBy(_._2).map {
+        case (date, metric) => (date, metric.size)
+      }.result)){ dbResult: Seq[(DateTime, Int)] =>
+        dbResult.map(pair => CountResponse(new DateTime(pair._1), pair._2)).toList
+      }
 }

--- a/app/kinesis/ProductionMetricsIndexStreamReader.scala
+++ b/app/kinesis/ProductionMetricsIndexStreamReader.scala
@@ -71,7 +71,7 @@ object ProductionMetricsStreamReader {
       (for {
         creationDate <- convertStringToDateTime(capiData.creationDate)
         firstPublicationDate <- convertStringToDateTime(capiData.firstPublicationDate)
-        existingMetric = db.getPublishingMetricsWithComposerId(Some(capiData.composerId))
+        existingMetric = db.getPublishingMetricsWithComposerId(Some(capiData.composerId)).fold(_ => None, identity)
         metric = MetricOpt(
           id = existingMetric.map(_.id).orElse(Some(UUID.randomUUID().toString)),
           originatingSystem = Some(capiData.originatingSystem),

--- a/app/kinesis/ProductionMetricsIndexStreamReader.scala
+++ b/app/kinesis/ProductionMetricsIndexStreamReader.scala
@@ -17,6 +17,7 @@ import models.{ProductionMetricsError, UnexpectedExceptionError}
 import play.api.Logger
 import util.Parser
 import util.Utils.convertStringToDateTime
+import cats.syntax.either._
 
 import scala.concurrent.duration.{Duration, _}
 
@@ -71,7 +72,7 @@ object ProductionMetricsStreamReader {
       (for {
         creationDate <- convertStringToDateTime(capiData.creationDate)
         firstPublicationDate <- convertStringToDateTime(capiData.firstPublicationDate)
-        existingMetric = db.getPublishingMetricsWithComposerId(Some(capiData.composerId)).fold(_ => None, identity)
+        existingMetric = db.getPublishingMetricsWithComposerId(Some(capiData.composerId)).toOption.flatten
         metric = MetricOpt(
           id = existingMetric.map(_.id).orElse(Some(UUID.randomUUID().toString)),
           originatingSystem = Some(capiData.originatingSystem),

--- a/app/kinesis/ProductionMetricsIndexStreamReader.scala
+++ b/app/kinesis/ProductionMetricsIndexStreamReader.scala
@@ -2,6 +2,7 @@ package lib.kinesis
 
 import java.util.UUID
 
+import cats.syntax.either._
 import com.amazonaws.auth.AWSCredentialsProviderChain
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorFactory
 import com.gu.editorialproductionmetricsmodels.models.EventType.CapiContent
@@ -9,7 +10,6 @@ import com.gu.editorialproductionmetricsmodels.models.{CapiData, KinesisEvent, M
 import config.Config
 import database.MetricsDB
 import io.circe.Json
-import io.circe.syntax._
 import lib.kinesis.EventProcessor.EventWithSize
 import lib.kinesis.ProductionMetricsStreamReader.ProductionMetricsEventProcessor
 import models.db.Metric
@@ -17,7 +17,6 @@ import models.{ProductionMetricsError, UnexpectedExceptionError}
 import play.api.Logger
 import util.Parser
 import util.Utils.convertStringToDateTime
-import cats.syntax.either._
 
 import scala.concurrent.duration.{Duration, _}
 

--- a/app/models/Errors.scala
+++ b/app/models/Errors.scala
@@ -3,10 +3,10 @@ package models
 sealed abstract class ProductionMetricsError(val message: String)
 
 case class InvalidJsonError(override val message: String) extends ProductionMetricsError(message)
+case class FailedFutureError(override val message: String) extends ProductionMetricsError(s"App hit an exception it did not expect: $message")
 case object UnexpectedExceptionError extends ProductionMetricsError("App hit an exception it did not expect.")
 case object NoRequestBodyError extends ProductionMetricsError("Request did not have a body.")
 case object ItemDoesNotExistError extends ProductionMetricsError("This item could not be found in the database.")
 case class CannotDeserializeKinesisEvent(override val message: String) extends ProductionMetricsError(message)
 case object UnexpectedDbExceptionError extends ProductionMetricsError("App hit an exception it did not expect when talking to the db.")
-case object FailedFutureError extends ProductionMetricsError("App hit an exception it did not expect when waiting for the future to complete.")
 case object InvalidOriginatingSystem extends ProductionMetricsError("The valid values for originating system are: composer and incopy.")

--- a/app/models/Errors.scala
+++ b/app/models/Errors.scala
@@ -8,4 +8,5 @@ case object NoRequestBodyError extends ProductionMetricsError("Request did not h
 case object ItemDoesNotExistError extends ProductionMetricsError("This item could not be found in the database.")
 case class CannotDeserializeKinesisEvent(override val message: String) extends ProductionMetricsError(message)
 case object UnexpectedDbExceptionError extends ProductionMetricsError("App hit an exception it did not expect when talking to the db.")
+case object FailedFutureError extends ProductionMetricsError("App hit an exception it did not expect when waiting for the future to complete.")
 case object InvalidOriginatingSystem extends ProductionMetricsError("The valid values for originating system are: composer and incopy.")

--- a/app/models/db/Metrics.scala
+++ b/app/models/db/Metrics.scala
@@ -114,7 +114,7 @@ case class Fork(
     wordCount: Int,
     revisionNumber: Int,
     issueDate: Option[DateTime] = None,
-    timeUntilFork: Option[Int] = None)
+    secondsUntilFork: Option[Int] = None)
 
 object Fork {
   def apply(forkData: ForkData): Fork =
@@ -128,5 +128,5 @@ object Fork {
       wordCount = tuple._4,
       revisionNumber = tuple._5,
       issueDate = tuple._6,
-      timeUntilFork = tuple._7)
+      secondsUntilFork = tuple._7)
 }

--- a/app/models/db/Metrics.scala
+++ b/app/models/db/Metrics.scala
@@ -112,17 +112,21 @@ case class Fork(
     composerId: String,
     time: DateTime,
     wordCount: Int,
-    revisionNumber: Int)
+    revisionNumber: Int,
+    issueDate: Option[DateTime] = None,
+    timeUntilFork: Option[Int] = None)
 
 object Fork {
   def apply(forkData: ForkData): Fork =
     new Fork(id = UUID.randomUUID.toString, forkData.composerId, forkData.time, forkData.wordCount, forkData.revisionNumber)
 
-  def customApply(tuple: (String, String, DateTime, Int, Int)): Fork =
+  def customApply(tuple: (String, String, DateTime, Int, Int, Option[DateTime], Option[Int])): Fork =
     Fork(
       id = tuple._1,
       composerId = tuple._2,
       time = tuple._3,
       wordCount = tuple._4,
-      revisionNumber = tuple._5)
+      revisionNumber = tuple._5,
+      issueDate = tuple._6,
+      timeUntilFork = tuple._7)
 }

--- a/app/models/db/MetricsFilters.scala
+++ b/app/models/db/MetricsFilters.scala
@@ -86,4 +86,4 @@ object CountResponse {
   implicit val metricEncoder: Encoder[Metric] = deriveEncoder
 }
 
-case class ForkResponse(date: DateTime, time: Int)
+case class ForkResponse(issueDate: DateTime, secondsUntilFork: Int)

--- a/app/models/db/MetricsFilters.scala
+++ b/app/models/db/MetricsFilters.scala
@@ -85,3 +85,5 @@ object CountResponse {
   }
   implicit val metricEncoder: Encoder[Metric] = deriveEncoder
 }
+
+case class ForkResponse(date: DateTime, time: Int)

--- a/app/models/db/Schema.scala
+++ b/app/models/db/Schema.scala
@@ -39,7 +39,7 @@ object Schema {
       creationTime,
       firstPublicationTime,
       roundTrip,
-      productionOffice) <> (Metric.customApply, Metric.unapply)
+      productionOffice) <> (Metric.customApply _, Metric.unapply _)
   }
 
   class DBInCopyMetric(tag: Tag) extends Table[InCopyMetric](tag, "incopy_metrics") {
@@ -63,7 +63,9 @@ object Schema {
     def time                = column[DateTime]("time")
     def wordCount           = column[Int]("word_count")
     def revisionNumber      = column[Int]("revision_number")
-    def * = (id, composerId, time, wordCount, revisionNumber) <> (Fork.customApply, Fork.unapply)
+    def issueDate           = column[Option[DateTime]]("issue_date")
+    def timeUntilFork       = column[Option[Int]]("time_until_fork")
+    def * = (id, composerId, time, wordCount, revisionNumber, issueDate, timeUntilFork) <> (Fork.customApply, Fork.unapply)
   }
 }
 

--- a/app/models/db/Schema.scala
+++ b/app/models/db/Schema.scala
@@ -64,8 +64,8 @@ object Schema {
     def wordCount           = column[Int]("word_count")
     def revisionNumber      = column[Int]("revision_number")
     def issueDate           = column[Option[DateTime]]("issue_date")
-    def timeUntilFork       = column[Option[Int]]("time_until_fork")
-    def * = (id, composerId, time, wordCount, revisionNumber, issueDate, timeUntilFork) <> (Fork.customApply, Fork.unapply)
+    def secondsUntilFork       = column[Option[Int]]("seconds_until_fork")
+    def * = (id, composerId, time, wordCount, revisionNumber, issueDate, secondsUntilFork) <> (Fork.customApply, Fork.unapply)
   }
 }
 

--- a/app/util/AsyncHelpers.scala
+++ b/app/util/AsyncHelpers.scala
@@ -17,7 +17,7 @@ object AsyncHelpers {
   def awaitWithTransformation[A, B](result: Future[A])(transformation: A => B): Either[ProductionMetricsError, B] = {
     val future: Future[Either[ProductionMetricsError, B]] = io(result)
       .map { r => Right(transformation(r)) }
-      .recover { case err => Left(FailedFutureError(err)) }
+      .recover { case err => Left(FailedFutureError(err.getMessage)) }
     Await.result(future, maxWait)
   }
   def await[A](result: Future[A]): Either[ProductionMetricsError, A] = awaitWithTransformation[A, A](result)(identity)

--- a/app/util/AsyncHelpers.scala
+++ b/app/util/AsyncHelpers.scala
@@ -17,7 +17,7 @@ object AsyncHelpers {
   def awaitWithTransformation[A, B](result: Future[A])(transformation: A => B): Either[ProductionMetricsError, B] = {
     val future: Future[Either[ProductionMetricsError, B]] = io(result)
       .map { r => Right(transformation(r)) }
-      .recover { case _ => Left(FailedFutureError) }
+      .recover { case err => Left(FailedFutureError(err)) }
     Await.result(future, maxWait)
   }
   def await[A](result: Future[A]): Either[ProductionMetricsError, A] = awaitWithTransformation[A, A](result)(identity)

--- a/app/util/PostgresOpsImport.scala
+++ b/app/util/PostgresOpsImport.scala
@@ -1,5 +1,6 @@
 package util
 
+import com.github.tototoshi.slick.PostgresJodaSupport._
 import org.joda.time.DateTime
 import slick.jdbc.PostgresProfile.api._
 

--- a/app/util/PostgresOpsImport.scala
+++ b/app/util/PostgresOpsImport.scala
@@ -1,0 +1,32 @@
+package util
+
+import org.joda.time.DateTime
+import slick.jdbc.PostgresProfile.api._
+
+/** Typeclass for importing postgres specific operations.
+  * Usage:
+  * - Add the new operation in the trait
+  * - Implement implicits for all the types that need to support that operation in the companion object
+  * - Define a convenience method in the implicit class and call it with slickField.convenienceMethod
+  * @tparam A - This is the type of the Slick column
+  */
+
+trait PostgresOpsImport[A <: Rep[_]] {
+  def dateTruncOp: (Rep[String], A) => A
+}
+
+object PostgresOpsImport {
+  implicit val dateTruncImplicit: PostgresOpsImport[Rep[DateTime]] = new PostgresOpsImport[Rep[DateTime]] {
+    def dateTruncOp: (Rep[String], Rep[DateTime]) => Rep[DateTime] = SimpleFunction.binary[String, DateTime, DateTime]("date_trunc")
+  }
+
+  implicit val dateTruncOptImplicit: PostgresOpsImport[Rep[Option[DateTime]]] = new PostgresOpsImport[Rep[Option[DateTime]]] {
+    def dateTruncOp: (Rep[String], Rep[Option[DateTime]]) => Rep[Option[DateTime]] = SimpleFunction.binary[String, Option[DateTime], Option[DateTime]]("date_trunc")
+  }
+
+  implicit class PostgresOps[A <: Rep[_]](data: A) {
+    def toDayDateTrunc(implicit postgresOpsImport: PostgresOpsImport[A]): A = postgresOpsImport.dateTruncOp("day", data)
+  }
+}
+
+

--- a/app/util/Utils.scala
+++ b/app/util/Utils.scala
@@ -41,6 +41,6 @@ object Utils {
     OriginatingSystem.withNameOption(originatingSystem).fold(Left(InvalidOriginatingSystem):Either[ProductionMetricsError, OriginatingSystem])(Right(_))
 
   def getTrackingTags(wsClient: WSClient, tagManagerUrl: String): Either[ProductionMetricsError, WSResponse] = await {
-    wsClient.url(tagManagerUrl).withQueryString(List(("type", "Tracking"),("limit", "100")):_*).get.map(Right(_)).recover{case _ => Left(UnexpectedExceptionError)}
+    wsClient.url(tagManagerUrl).withQueryString(List(("type", "Tracking"),("limit", "100")):_*).get
   }
 }

--- a/conf/routes
+++ b/conf/routes
@@ -3,6 +3,7 @@ GET     /                                 controllers.App.index
 GET     /api/originatingSystem/:system    controllers.App.getStartedIn(system: String)
 GET     /api/commissioningDesks           controllers.App.getCommissioningDeskList
 GET     /api/inWorkflow/:inWorkflow       controllers.App.getWorkflowData(inWorkflow: Boolean)
+GET     /api/fork                         controllers.App.getForks()
 
 # endpoints for posting data from other apps
 OPTIONS /api/metric/*url                  controllers.App.allowCORSAccess(methods = "PUT, POST, DELETE", url: String)


### PR DESCRIPTION
- Adds new endpoint that returns a list of fork info pairs:
```
[
    {
        "issueDate": "2017-09-25T00:00:00Z",
        "secondsUntilFork": 2879
    },
    {
        "issueDate": "2017-08-26T00:00:00Z",
        "secondsUntilFork": 29108
    }
]
```
- Adds quite a bit of refactoring for the `await` function (happy to take suggestions on how to improve it) and the way we import functions from postgres.