### PR TITLE
Books endpoint

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -90,5 +90,5 @@ class Application(implicit val wsClient: WSClient, val db: MetricsDB) extends Co
     }
   }
 
-  def getNewspaperBookList = Action(APIResponse(db.getDistinctNewspaperBooks))
+  def getNewspaperBookList = APIAuthAction(APIResponse(db.getDistinctNewspaperBooks))
 }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -89,4 +89,6 @@ class Application(implicit val wsClient: WSClient, val db: MetricsDB) extends Co
       db.getForks(MetricsFilters(req.queryString).copy(newspaperBook = Some(newspaperBook)))
     }
   }
+
+  def getNewspaperBookList = Action(APIResponse(db.getDistinctNewspaperBooks))
 }

--- a/app/database/MetricsDB.scala
+++ b/app/database/MetricsDB.scala
@@ -54,4 +54,7 @@ class MetricsDB(implicit val db: Database) {
       }.result)){ dbResult: Seq[(DateTime, Int)] =>
         dbResult.map(pair => CountResponse(new DateTime(pair._1), pair._2)).toList
       }
+
+  def getDistinctNewspaperBooks: Either[ProductionMetricsError, Seq[Option[String]]] =
+    await(db.run(metricsTable.filter(!_.newspaperBook.isEmpty).map(_.newspaperBook).distinct.result))
 }

--- a/app/services/EC2Client.scala
+++ b/app/services/EC2Client.scala
@@ -1,7 +1,7 @@
 package services
 
 import com.amazonaws.regions.{Region, Regions}
-import com.amazonaws.services.ec2.AmazonEC2Client
+import com.amazonaws.services.ec2.AmazonEC2ClientBuilder
 import com.amazonaws.services.ec2.model.{DescribeTagsRequest, Filter}
 import com.amazonaws.util.EC2MetadataUtils
 
@@ -11,7 +11,7 @@ import scala.collection.JavaConversions._
 object EC2Client {
   lazy val region = Option(Regions.getCurrentRegion).getOrElse(Region.getRegion(Regions.EU_WEST_1))
 
-  lazy val EC2Client = region.createClient(classOf[AmazonEC2Client], null, null)
+  lazy val EC2Client = AmazonEC2ClientBuilder.standard().withRegion(region.getName).build()
 }
 
 trait AwsInstanceTags {

--- a/conf/routes
+++ b/conf/routes
@@ -1,10 +1,10 @@
 GET     /                                 controllers.Application.index
 
-GET     /api/originatingSystem/:system    controllers.App.getStartedIn(system: String)
-GET     /api/commissioningDesks           controllers.App.getCommissioningDeskList
-GET     /api/inWorkflow/:inWorkflow       controllers.App.getWorkflowData(inWorkflow: Boolean)
-GET     /api/fork/                        controllers.App.getForks(newspaperBook: String)
-GET     /api/newspaperBooks               controllers.App.getNewspaperBookList
+GET     /api/originatingSystem/:system    controllers.Application.getStartedIn(system: String)
+GET     /api/commissioningDesks           controllers.Application.getCommissioningDeskList
+GET     /api/inWorkflow/:inWorkflow       controllers.Application.getWorkflowData(inWorkflow: Boolean)
+GET     /api/fork/                        controllers.Application.getForks(newspaperBook: String)
+GET     /api/newspaperBooks               controllers.Application.getNewspaperBookList
 
 # endpoints for posting data from other apps
 OPTIONS /api/metric/*url                  controllers.Application.allowCORSAccess(methods = "PUT, POST, DELETE", url: String)

--- a/conf/routes
+++ b/conf/routes
@@ -1,9 +1,10 @@
 GET     /                                 controllers.Application.index
 
-GET     /api/originatingSystem/:system    controllers.Application.getStartedIn(system: String)
-GET     /api/commissioningDesks           controllers.Application.getCommissioningDeskList
-GET     /api/inWorkflow/:inWorkflow       controllers.Application.getWorkflowData(inWorkflow: Boolean)
-GET     /api/fork                         controllers.Application.getForks(newspaperBook: String)
+GET     /api/originatingSystem/:system    controllers.App.getStartedIn(system: String)
+GET     /api/commissioningDesks           controllers.App.getCommissioningDeskList
+GET     /api/inWorkflow/:inWorkflow       controllers.App.getWorkflowData(inWorkflow: Boolean)
+GET     /api/fork/                        controllers.App.getForks(newspaperBook: String)
+GET     /api/newspaperBooks               controllers.App.getNewspaperBookList
 
 # endpoints for posting data from other apps
 OPTIONS /api/metric/*url                  controllers.Application.allowCORSAccess(methods = "PUT, POST, DELETE", url: String)


### PR DESCRIPTION
Add endpoint for getting all newspaper books currently in use in the metrics DB
Also stop using deprecated method for getting an EC2 client