### PR TITLE
use signature version 4 to authenticate requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ You'll need:
  * Set up config locally using [this guide](#local-config)
  * Setup the nginx mapping by following the instructions in the [dev-nginx readme](https://github.com/guardian/dev-nginx#install-config-for-an-application).
  * Install Client Side Dependencies with `./scripts/setup.sh`
- 
+
 Running the App:
  * Set up the Postgres database: We use a RDS Posgres database running in the composer account in AWS. To connect to it locally run `./setup-ssh-tunnel.sh -t <Endpoint of of database without the port number>`. Which database you use mush match the config you have. I.e. use the DEV database with the DEV config and CODE database with CODE config. Get the endpoint by looking in the Composer AWS account.
  * Run Client and Server: `./scripts/start.sh`
  * Run using sbt: `sbt "run 9051"`. (For quick restart you should run `sbt` and then `run 9051`, so that you can exit the application without exiting sbt.)
-   
+
 ### Compiling Client Side Dependencies
 
 This project requires Node version 6. To manage different versions of node you can use [node version manager](https://github.com/creationix/nvm).
@@ -56,7 +56,10 @@ This project uses [Configuration Magic](https://github.com/guardian/configuratio
 This project uses [Configuration Magic](https://github.com/guardian/configuration-magic/) so you need to fetch a config file to use locally. Do this with the `fetch-config.sh` script. By default this will get the DEV config but you can also pass it a `DEV` or `CODE` parameter.
 
 `./fetch-config.sh CODE` or `./fetch-config.sh DEV`
- 
+
+
+ - If you get an error message saying that you requred AWS Signature Version 4, configure your aws cli by running `aws configure set default.s3.signature_version s3v4`
+
 The DEV config is best to use when developing code that makes changes to the database or writes and reads from kinesis stream. The CODE config points to the CODE database and is populated with the same data as in the PROD database so is useful when data that reflects PROD is needed.
 
  - Fetch config from S3 with `./fetch-config.sh`. This gets the `DEV` config

--- a/fetch-config.sh
+++ b/fetch-config.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
+region="eu-west-1"
 env=$( echo "${1:-DEV}" | tr '[:lower:]' '[:upper:]' )
 if [[ "$env" != DEV && "$env" != CODE ]]; then
  env=DEV
 fi
 
 mkdir -p ~/.configuration-magic/
-aws s3 cp s3://guconf-flexible/editorial-production-metrics/${env}/editorial-production-metrics.conf ~/.configuration-magic/editorial-production-metrics.conf --profile composer
+aws s3 cp s3://guconf-flexible/editorial-production-metrics/${env}/editorial-production-metrics.conf ~/.configuration-magic/editorial-production-metrics.conf --profile composer --region $region


### PR DESCRIPTION
So that we can fetch configs from encrypted buckets.