### PR TITLE
update filters correctly in reducer

### DIFF
--- a/public/js/reducers/updateFilterReducer.js
+++ b/public/js/reducers/updateFilterReducer.js
@@ -11,7 +11,7 @@ const initialState = {
 const filterVals = (state = initialState, action) => {
     switch (action.type) {
     case 'UPDATE_FILTER':
-        return Object.assign({}, state, filterVals);
+        return Object.assign({}, state, action.filterObj);
     default:
         return state;
     }


### PR DESCRIPTION
The reason why the new filters weren't showing was that they were not being saved after selecting them. This should fix a couple of other filtering bugs (e.g. showing the correct filters on downloaded csvs).