### PR TITLE
Fix missing fork data

### DIFF
--- a/docs/addingMetrics.md
+++ b/docs/addingMetrics.md
@@ -56,9 +56,9 @@ All api calls are done with [axios](https://github.com/mzabriskie/axios). To fet
 
 #### Merging the data into the store
 
-All api calls for the different charts are triggered by the `filterDesk` action creator in `public/js/actions/index.js`, which dispatches async calls thanks to the `thunk` middleware. Currently, every endpoint for every metrics is called every time the url's query params have been changed by the filters (thanks to a custom routing middleware).
+All api calls for the different charts are triggered by the `runFilter` action creator in `public/js/actions/index.js`, which dispatches async calls thanks to the `thunk` middleware. Currently, every endpoint for every metrics is called every time the url's query params have been changed by the filters (thanks to a custom routing middleware).
 
-You should add the name of your new metric to the list in `public/js/utils/chartsList`: if you are consistent with the naming of the metric across the app, you should be able to easily add the new api call to the ones already being executed by the effect. The `filterDesk` action creator triggers the merge actions for every chart if fetching is successful, and the error actions if fetching fails. These actions are being listened by the reducer in `public/js/reducers/chartsReducer`, this is where the fetched data is manipulated and merged into the store.
+You should add the name of your new metric to the list in `public/js/utils/chartsList`: if you are consistent with the naming of the metric across the app, you should be able to easily add the new api call to the ones already being executed by the effect. The `runFilter` action creator triggers the merge actions for every chart if fetching is successful, and the error actions if fetching fails. These actions are being listened by the reducer in `public/js/reducers/chartsReducer`, this is where the fetched data is manipulated and merged into the store.
 
 You need to add your new metric to the reducers's initial state, following this structure:
 
@@ -79,13 +79,13 @@ All chart components are stored in `public/js/componets/Charts`. Just add a new 
 
 #### Adding a new filter
 
-There is a unique reducer for all filters, in `updateFilterReducer.js`: just update the inital state, then in `Filters.js` add your filter and update the object by launching the `filterDesk()` action with the updated `filterVals` when your filter changes. Example: 
+There is a unique reducer for all filters, in `updateFilterReducer.js`: just update the inital state, then in `Filters.js` add your filter and update the object by launching the `runFilter()` action with the updated `filterVals` when your filter changes. Example: 
 ```
-<select onChange={event => filterDesk({ ...filterVals, theFilterBeingUpdated: event.target.value })}> ... </select>
+<select onChange={event => runFilter({ theFilterBeingUpdated: event.target.value })}> ... </select>
 ```
 You can add the new query param in `Api.js` by simply adding a key to the `params` object built by the `buildQueryParams` function. 
 
-`filterDesk` will update the filter object with the new value and proceed to call the api again with the updated values.
+`runFilter` will update the filter object with the new value and proceed to call the api again with the updated values.
 
 #### Routing
 

--- a/public/js/actions/filtersActions.js
+++ b/public/js/actions/filtersActions.js
@@ -12,3 +12,13 @@ export const getCommissioningDesksFailed = (error) => ({
     type: 'GET_COMMISSIONING_DESKS_FAILED',
     error
 });
+
+export const updateNewspaperBooks = (booksList) => ({
+    type: 'UPDATE_NEWSPAPER_BOOKS',
+    booksList
+});
+
+export const getNewspaperBooksFailed = (error) => ({
+    type: 'GET_NEWSPAPER_BOOKS_FAILED',
+    error
+});

--- a/public/js/actions/index.js
+++ b/public/js/actions/index.js
@@ -46,7 +46,7 @@ const filtersToArgs = (chart, filterObj) =>
     CHART_FILTERS_MAP[chart].map(filter => filterObj[filter]);
 
 // Test whether any of the changed filters are used for this chart
-const chartNeedsUpdate = (filterChangeset = {}) => chart => {
+const chartNeedsUpdate = (chart, filterChangeset = {}) => {
     const changedFilters = Object.keys(filterChangeset);
     const chartFilters = CHART_FILTERS_MAP[chart];
 
@@ -61,7 +61,7 @@ export const runFilter = (filterChangeset = {}) => {
         dispatch(toggleIsUpdatingCharts(true));
         const { startDate, endDate } = updatedFilters;
         CHART_LIST
-            .filter(chartNeedsUpdate(filterChangeset))
+            .filter(chart => chartNeedsUpdate(chart, filterChangeset))
             .map(chart => {
                 api[`get${chart}`](...filtersToArgs(chart, updatedFilters))
                     .then(chartData => updateAttemptActions(chartData, chart, startDate, endDate, dispatch))

--- a/public/js/actions/index.js
+++ b/public/js/actions/index.js
@@ -59,11 +59,11 @@ export const runFilter = (filterChangeset = {}) => {
         const updatedFilters = { ...filterVals, ...filterChangeset };
         dispatch(updateFilter(updatedFilters));
         dispatch(toggleIsUpdatingCharts(true));
-        const { startDate, endDate } = filterVals;
+        const { startDate, endDate } = updatedFilters;
         CHART_LIST
             .filter(chartNeedsUpdate(filterChangeset))
             .map(chart => {
-                api[`get${chart}`](...filtersToArgs(chart, filterVals))
+                api[`get${chart}`](...filtersToArgs(chart, updatedFilters))
                     .then(chartData => updateAttemptActions(chartData, chart, startDate, endDate, dispatch))
                     .catch(error => responseFailActions(chart, error, dispatch));
             });
@@ -87,7 +87,6 @@ export const fetchNewspaperBooks = () => {
         api.getNewspaperBooks()
             .then(response => {
                 const booksList = response.data;
-                booksList.push('all');
                 dispatch(updateNewspaperBooks(booksList));
             })
             .catch(dispatch(getNewspaperBooksFailed));

--- a/public/js/actions/index.js
+++ b/public/js/actions/index.js
@@ -1,4 +1,4 @@
-import chartList from 'utils/chartList';
+import { CHART_LIST, CHART_ARGS_MAP } from 'utils/chartList';
 import {
     updateComposerVsIncopy, 
     getComposerVsIncopyFailed, 
@@ -9,7 +9,13 @@ import {
 
 } from './chartsActions';
 import { toggleIsUpdatingCharts } from './uiActions';
-import { updateFilter, updateCommissioningDesks, getCommissioningDesksFailed } from './filtersActions';
+import {
+  updateFilter,
+  updateCommissioningDesks,
+  getCommissioningDesksFailed,
+  updateNewspaperBooks,
+  getNewspaperBooksFailed
+} from "./filtersActions";
 import api from 'services/Api';
 
 const chartsActions = { 
@@ -35,13 +41,16 @@ const responseFailActions = (chart, error, dispatch) => {
 
 /*-------- DISPATCHABLE --------*/
 
+const filtersToArgs = (chart, filterObj) =>
+    CHART_ARGS_MAP[chart].map(filter => filterObj[filter]);
+
 export const filterDesk = (filterObj = {}) => {
     return (dispatch) => {
         dispatch(updateFilter(filterObj));
         dispatch(toggleIsUpdatingCharts(true));
-        const { startDate, endDate, desk, productionOffice } = filterObj;
-        chartList.map(chart => {
-            api[`get${chart}`](startDate, endDate, desk, productionOffice)
+        const { startDate, endDate } = filterObj;
+        CHART_LIST.map(chart => {
+            api[`get${chart}`](...filtersToArgs(chart, filterObj))
                 .then(chartData => updateAttemptActions(chartData, chart, startDate, endDate, dispatch))
                 .catch(error => responseFailActions(chart, error, dispatch));
         });
@@ -60,11 +69,23 @@ export const fetchCommissioningDesks = () => {
     };
 };
 
+export const fetchNewspaperBooks = () => {
+    return (dispatch) => {
+        api.getNewspaperBooks()
+            .then(response => {
+                const booksList = response.data;
+                booksList.push('all');
+                dispatch(updateNewspaperBooks(booksList));
+            })
+            .catch(dispatch(getNewspaperBooksFailed));
+    };
+};
+
 export const toggleStackChart = (isStacked) => ({
     type: 'TOGGLE_STACK_CHART',
     isStacked
 });
 
-const actions = { filterDesk, fetchCommissioningDesks, toggleStackChart };
+const actions = { filterDesk, fetchCommissioningDesks, fetchNewspaperBooks, toggleStackChart };
 
 export default actions;

--- a/public/js/components/Charts/Charts.js
+++ b/public/js/components/Charts/Charts.js
@@ -87,7 +87,7 @@ const Charts = ({ charts, isUpdating, toggleStackChart, filterVals }) => {
                         data={charts.forkTime.data}
                         noDataMessage={<NoDataMessage filters={CHART_FILTERS_MAP["ForkTime"]} />}
                         height={250}
-                        yLabel='Time since fork'
+                        yLabel='Time to Publication'
                     />
                 </Col>
             </Row>

--- a/public/js/components/Charts/Charts.js
+++ b/public/js/components/Charts/Charts.js
@@ -3,6 +3,13 @@ import { Themes } from 'formidable-charts';
 import { Grid, Row, Col } from 'react-flexbox-grid';
 import AreaChartWrap from './AreaChartWrap';
 import ScatterChartWrap from './ScatterChartWrap';
+import { CHART_FILTERS_MAP } from "../../utils/chartList";
+
+const NoDataMessage = ({ filters }) =>
+    <div className="no-data">
+        No data, please update any of the following:<br />
+        <span className="filters">{filters.join(", ")}</span>
+    </div>
 
 const Charts = ({ charts, isUpdating, toggleStackChart, filterVals }) => {
 
@@ -78,6 +85,7 @@ const Charts = ({ charts, isUpdating, toggleStackChart, filterVals }) => {
                         hasCsvButton={true}
                         scale='time'
                         data={charts.forkTime.data}
+                        noDataMessage={<NoDataMessage filters={CHART_FILTERS_MAP["ForkTime"]} />}
                         height={250}
                         yLabel='Time since fork'
                     />

--- a/public/js/components/Charts/ScatterChartWrap.js
+++ b/public/js/components/Charts/ScatterChartWrap.js
@@ -18,7 +18,7 @@ const ScatterChartWrap = ({ scale, error, height, titleHeader, yLabel, data, get
             }}
             yAxis={{
                 label: yLabel,
-                tickFormat: (datum) => `${Math.round(datum / 3600)}h`
+                tickFormat: (datum) => `${datum}h`
             }}
         />
         <ChartsToggles

--- a/public/js/components/Charts/ScatterChartWrap.js
+++ b/public/js/components/Charts/ScatterChartWrap.js
@@ -6,28 +6,38 @@ import ChartsToggles  from '../ChartsToggles';
 
 const customisedTheme = Object.assign({}, Themes.simple, ChartTheme);
 
-const ScatterChartWrap = ({ scale, error, height, titleHeader, yLabel, data, getClassName, chartType, hasToggle, hasCsvButton, filterVals }) =>
+const hasData = (data) => (((data || [])[0] || {})["data"] || []).length;
+
+const ScatterChartWrap = ({ scale, error, noDataMessage, height, titleHeader, yLabel, data, getClassName, chartType, hasToggle, hasCsvButton, filterVals }) =>
     <div className={getClassName(error)}>
         {titleHeader}
-        <ScatterChart
-            height={height}
-            theme={customisedTheme}
-            series={data.absolute}
-            xAxis={{
-                scale
-            }}
-            yAxis={{
-                label: yLabel,
-                tickFormat: (datum) => `${datum}h`
-            }}
-        />
-        <ChartsToggles
-            filterVals={filterVals}
-            hasToggle={hasToggle}
-            chartType={chartType}
-            data={data}
-            hasCsvButton={hasCsvButton}
-        />
+        {hasData(data.absolute) ? (
+            <div>
+                <ScatterChart
+                    height={height}
+                    theme={customisedTheme}
+                    series={data.absolute}
+                    xAxis={{
+                        scale
+                    }}
+                    yAxis={{
+                        label: yLabel,
+                        tickFormat: (datum) => `${datum}h`
+                    }}
+                />
+                <ChartsToggles
+                    filterVals={filterVals}
+                    hasToggle={hasToggle}
+                    chartType={chartType}
+                    data={data}
+                    hasCsvButton={hasCsvButton}
+                />
+            </div>
+        ) : (
+            <div>
+                {noDataMessage}
+            </div>
+        )}
     </div>;
 
 export default ScatterChartWrap;

--- a/public/js/components/Filters/Filters.js
+++ b/public/js/components/Filters/Filters.js
@@ -15,7 +15,7 @@ export default class Filters extends Component {
     state = { focusedInput: null };
 
     render() {
-        const { filterVals, isUpdating, desks, newspaperBooks, filterDesk } = this.props;
+        const { filterVals, isUpdating, desks, newspaperBooks, runFilter } = this.props;
         return (
             <form className="form">
                 <Grid fluid>
@@ -26,7 +26,7 @@ export default class Filters extends Component {
                                     <div>Filter by Desk:</div>
                                     <select
                                         className="form__field form__field--select"
-                                        onChange={event => filterDesk({ ...filterVals, desk: event.target.value })}
+                                        onChange={event => runFilter({ desk: event.target.value })}
                                         value={filterVals.desk}
                                         disabled={isUpdating}
                                     >
@@ -41,7 +41,7 @@ export default class Filters extends Component {
                                     <div>Filter by Newspaper book:</div>
                                     <select
                                         className="form__field form__field--select"
-                                        onChange={event => filterDesk({ ...filterVals, newspaperBook: event.target.value })}
+                                        onChange={event => runFilter({ newspaperBook: event.target.value })}
                                         value={filterVals.newspaperBook}
                                         disabled={isUpdating}
                                     >
@@ -56,7 +56,7 @@ export default class Filters extends Component {
                                     <div>Filter by Office:</div>
                                     <select
                                         className="form__field form__field--select"
-                                        onChange={event => filterDesk({ ...filterVals, productionOffice: event.target.value })}
+                                        onChange={event => runFilter({ productionOffice: event.target.value })}
                                         value={filterVals.productionOffice}
                                         disabled={isUpdating}
                                     >   
@@ -81,7 +81,7 @@ export default class Filters extends Component {
                                             disabled={isUpdating}
                                             startDate={filterVals.startDate}
                                             endDate={filterVals.endDate}
-                                            onDatesChange={({ startDate, endDate }) => endDate > startDate ? filterDesk({ ...filterVals, startDate: startDate.utc().startOf('day'), endDate: endDate.utc().endOf('day') }) : false }
+                                            onDatesChange={({ startDate, endDate }) => endDate > startDate ? runFilter({ ...filterVals, startDate: startDate.utc().startOf('day'), endDate: endDate.utc().endOf('day') }) : false }
                                             focusedInput={this.state.focusedInput}
                                             onFocusChange={focusedInput => this.setState({ focusedInput })}
                                             isOutsideRange={(day) => day.isAfter(moment())}

--- a/public/js/components/Filters/Filters.js
+++ b/public/js/components/Filters/Filters.js
@@ -2,20 +2,25 @@ import React, { Component } from 'react';
 import { Grid, Row, Col } from 'react-flexbox-grid';
 import moment from 'moment';
 import { DateRangePicker } from 'react-dates';
-import { formatDeskName } from 'helpers/chartsHelpers';
+import { tagToName } from 'helpers/chartsHelpers';
 
-const renderDesks = (desks) => desks.sort().map((desk, key) => <option value={desk} key={`desk-filter-key-${key}`}>{formatDeskName(desk)}</option>);
+const renderName = desks =>
+  desks.sort().map((desk, key) => (
+    <option value={desk} key={`desk-filter-key-${key}`}>
+      {tagToName(desk)}
+    </option>
+  ));
 
 export default class Filters extends Component {
     state = { focusedInput: null };
 
     render() {
-        const { filterVals, isUpdating, desks, filterDesk } = this.props;
+        const { filterVals, isUpdating, desks, newspaperBooks, filterDesk } = this.props;
         return (
             <form className="form">
                 <Grid fluid>
                     <Row>
-                        <Col xs={12} md={4}>
+                        <Col xs={12} md={3}>
                             <div className="form__row">
                                 <label>
                                     <div>Filter by Desk:</div>
@@ -25,12 +30,27 @@ export default class Filters extends Component {
                                         value={filterVals.desk}
                                         disabled={isUpdating}
                                     >
-                                        {renderDesks(desks)}
+                                        {renderName(desks)}
                                     </select>
                                 </label>
                             </div>
                         </Col>
-                        <Col xs={12} md={4}>
+                        <Col xs={12} md={3}>
+                            <div className="form__row">
+                                <label>
+                                    <div>Filter by Newspaper book:</div>
+                                    <select
+                                        className="form__field form__field--select"
+                                        onChange={event => filterDesk({ ...filterVals, newspaperBook: event.target.value })}
+                                        value={filterVals.newspaperBook}
+                                        disabled={isUpdating}
+                                    >
+                                        {renderName(newspaperBooks)}
+                                    </select>
+                                </label>
+                            </div>
+                        </Col>
+                        <Col xs={12} md={3}>
                             <div className="form__row">
                                 <label>
                                     <div>Filter by Office:</div>
@@ -48,7 +68,7 @@ export default class Filters extends Component {
                                 </label>
                             </div>
                         </Col>
-                        <Col xs={12} md={4}>
+                        <Col xs={12} md={3}>
                             <div className="form__row">
                                 <label>
                                     <div>Time Range:</div>

--- a/public/js/components/Filters/Filters.js
+++ b/public/js/components/Filters/Filters.js
@@ -20,7 +20,7 @@ export default class Filters extends Component {
             <form className="form">
                 <Grid fluid>
                     <Row>
-                        <Col xs={12} md={3}>
+                        <Col xs={12} md={2}>
                             <div className="form__row">
                                 <label>
                                     <div>Filter by Desk:</div>
@@ -35,10 +35,10 @@ export default class Filters extends Component {
                                 </label>
                             </div>
                         </Col>
-                        <Col xs={12} md={3}>
+                        <Col xs={12} md={2}>
                             <div className="form__row">
                                 <label>
-                                    <div>Filter by Newspaper book:</div>
+                                    <div>Filter by Newspaper:</div>
                                     <select
                                         className="form__field form__field--select"
                                         onChange={event => runFilter({ newspaperBook: event.target.value })}
@@ -50,7 +50,7 @@ export default class Filters extends Component {
                                 </label>
                             </div>
                         </Col>
-                        <Col xs={12} md={3}>
+                        <Col xs={12} md={2}>
                             <div className="form__row">
                                 <label>
                                     <div>Filter by Office:</div>
@@ -68,7 +68,7 @@ export default class Filters extends Component {
                                 </label>
                             </div>
                         </Col>
-                        <Col xs={12} md={3}>
+                        <Col xs={12} md={4}>
                             <div className="form__row">
                                 <label>
                                     <div>Time Range:</div>

--- a/public/js/containers/App.js
+++ b/public/js/containers/App.js
@@ -9,10 +9,11 @@ import Charts from 'components/Charts/Charts';
 class App extends Component {
     componentDidMount() {
         this.props.actions.fetchCommissioningDesks();
+        this.props.actions.fetchNewspaperBooks();
     }
 
     render() {
-        const { filterVals, isUpdating, charts, commissioningDesks, actions } = this.props;
+        const { filterVals, isUpdating, charts, commissioningDesks, newspaperBooks, actions } = this.props;
         return (
             <Page>
                 <div className='top-section'>
@@ -22,6 +23,7 @@ class App extends Component {
                     filterVals={filterVals}
                     isUpdating={isUpdating}
                     desks={commissioningDesks.desksList}
+                    newspaperBooks={newspaperBooks.booksList}
                     filterDesk={actions.filterDesk}
                 />
                 <Charts
@@ -40,12 +42,13 @@ const mapDispatchToProps = (dispatch) => ({
 });
 
 const mapStateToProps = (state) => {
-    const { filterVals, charts, isUpdating, commissioningDesks } = state;
+    const { filterVals, charts, isUpdating, commissioningDesks, newspaperBooks } = state;
     return {
         filterVals,
         charts,
         isUpdating,
-        commissioningDesks
+        commissioningDesks,
+        newspaperBooks
     };
 };
 

--- a/public/js/containers/App.js
+++ b/public/js/containers/App.js
@@ -24,7 +24,7 @@ class App extends Component {
                     isUpdating={isUpdating}
                     desks={commissioningDesks.desksList}
                     newspaperBooks={newspaperBooks.booksList}
-                    filterDesk={actions.filterDesk}
+                    runFilter={actions.runFilter}
                 />
                 <Charts
                     charts={charts}

--- a/public/js/helpers/chartsHelpers.js
+++ b/public/js/helpers/chartsHelpers.js
@@ -56,7 +56,13 @@ const fillMissingDates = (startDate, endDate, data) => {
 // Components helpers
 
 // Remove the 'tracking/commissioningdesk/' bit from the desk identifier string, replace dashes with spaces and capitalize each word
-const formatDeskName = deskName => deskName.substr(27).replace(/-/g, ' ').replace(/\b\w/g, x => x.toUpperCase());
+const tagToName = deskName =>
+  deskName
+    .replace("tracking/commissioningdesk/", "")
+    .replace(/the(guardian|observer)/, "The $1")
+    .replace(/-/g, " ")
+    .replace(/\//g, " - ")
+    .replace(/\b\w/g, x => x.toUpperCase());
 
 const humanizeKeys = (obj, system) => ({ date: moment(obj.x).format('ddd, Do MMMM YYYY'), [`${system}`]: obj['y'] });
 
@@ -85,11 +91,11 @@ const downloadCSV = (data, chartType, filterVals) => {
         csv = csv.join('\r\n');
         const blob = new Blob([csv], {type: 'text/csv;charset=utf-8'});
         const dateRangeString = `${filterVals.startDate.format('DD/MM/YYYY')}-${filterVals.endDate.format('DD/MM/YYYY')}`;
-        const fileName = `${chartType}_office=${filterVals.productionOffice}_desk=${formatDeskName(filterVals.desk)}_dateRange=${dateRangeString}.csv`;
+        const fileName = `${chartType}_office=${filterVals.productionOffice}_desk=${tagToName(filterVals.desk)}_dateRange=${dateRangeString}.csv`;
         saveAs(blob, fileName);
     } catch(e) {
         console.log(`Could not download csv due to this error: ${e.message}`);
     }
 };
 
-export { createPartialsList, formattedSeries, createYTotalsList, compareDates, compareIssueDates, fillMissingDates, downloadCSV, formatDeskName };
+export { createPartialsList, formattedSeries, createYTotalsList, compareDates, compareIssueDates, fillMissingDates, downloadCSV, tagToName };

--- a/public/js/reducers/chartsReducer.js
+++ b/public/js/reducers/chartsReducer.js
@@ -107,10 +107,11 @@ const charts = (state = initialState, action) => {
             return {
                 data: series.data.map((dataPoint) => {
                     const date = moment(dataPoint['issueDate']).utc();
+                    const hours = dataPoint.timeToPublication / 3600 / 1000;
                     return {
                         x: date.valueOf(),
-                        y: dataPoint.secondsUntilFork,
-                        label: `${(dataPoint.secondsUntilFork / 3600).toFixed(1)} hours`,
+                        y: hours,
+                        label: `${hours.toFixed(1)} hours`,
                         size: 2.5
                     };
                 })

--- a/public/js/reducers/newspaperBooksReducer.js
+++ b/public/js/reducers/newspaperBooksReducer.js
@@ -1,5 +1,5 @@
 const initialState = {
-    booksList: ['all']
+    booksList: []
 };
 
 const newspaperBooks = (state = initialState, action) => {

--- a/public/js/reducers/newspaperBooksReducer.js
+++ b/public/js/reducers/newspaperBooksReducer.js
@@ -1,0 +1,23 @@
+const initialState = {
+    booksList: ['all']
+};
+
+const newspaperBooks = (state = initialState, action) => {
+    const { booksList, error, type } = action;
+    switch (type) {
+    case 'UPDATE_NEWSPAPER_BOOKS':
+        return {
+            ...state,
+            booksList
+        };
+    case 'GET_NEWSPAPER_BOOKS_FAILED':
+        return {
+            ...state,
+            error
+        };
+    default:
+        return state;
+    }
+};
+
+export default newspaperBooks;

--- a/public/js/reducers/updateFilterReducer.js
+++ b/public/js/reducers/updateFilterReducer.js
@@ -2,7 +2,7 @@ import moment from 'moment';
 
 const initialState = {
     desk: 'tracking/commissioningdesk/all',
-    newspaperBook: 'all',
+    newspaperBook: 'theguardian/main', // TODO: set this programatically
     productionOffice: 'all',
     startDate: moment().utc().startOf('day').subtract(7,'d'),
     endDate: moment().utc().endOf('day')

--- a/public/js/reducers/updateFilterReducer.js
+++ b/public/js/reducers/updateFilterReducer.js
@@ -2,6 +2,7 @@ import moment from 'moment';
 
 const initialState = {
     desk: 'tracking/commissioningdesk/all',
+    newspaperBook: 'all',
     productionOffice: 'all',
     startDate: moment().utc().startOf('day').subtract(7,'d'),
     endDate: moment().utc().endOf('day')

--- a/public/js/redux/index.js
+++ b/public/js/redux/index.js
@@ -5,6 +5,7 @@ import charts from 'reducers/chartsReducer';
 import filterVals from 'reducers/updateFilterReducer';
 import isUpdating from 'reducers/updateProgressReducer';
 import commissioningDesks from 'reducers/commissioningDesksReducer';
+import newspaperBooks from 'reducers/newspaperBooksReducer';
 
 export default () => {
     /* ------------- Assemble The Reducers ------------- */
@@ -13,6 +14,7 @@ export default () => {
         charts,
         isUpdating,
         commissioningDesks,
+        newspaperBooks,
         routing 
     });
 

--- a/public/js/services/Api.js
+++ b/public/js/services/Api.js
@@ -18,6 +18,8 @@ const getWorkflowCount = (isInWorkflow, startDate, endDate, desk, productionOffi
 
 const getCommissioningDesks = () => pandaFetch('api/commissioningDesks', null);
 
+const getNewspaperBooks = () => pandaFetch('api/newspaperBooks', null);
+
 const getForkTime = (startDate, endDate, newspaperBook) => pandaFetch(`api/fork/${newspaperBook}`, buildQueryParams(startDate, endDate));
 
 const getComposerVsIncopy = (startDate, endDate, desk, productionOffice) =>
@@ -44,5 +46,6 @@ export default {
     getComposerVsIncopy,
     getInWorkflowVsNotInWorkflow,
     getCommissioningDesks,
+    getNewspaperBooks,
     getForkTime
 };

--- a/public/js/services/routingMiddleware.js
+++ b/public/js/services/routingMiddleware.js
@@ -1,5 +1,5 @@
 import { replace } from 'react-router-redux';
-import { filterDesk } from 'actions';
+import { runFilter } from 'actions';
 import _isEqual from 'lodash/isEqual';
 import moment from 'moment';
 import { objectToParamString, paramStringToObject } from 'helpers/routingHelpers';
@@ -34,7 +34,7 @@ export const updateStateFromUrlChangeMiddleware = ({ dispatch, getState }) => (n
         filterObj['endDate'] = moment(filterObj['endDate']).utc().endOf('day');
 
         if (!_isEqual(filterObj, newState.filterVals)) {
-            dispatch(filterDesk(filterObj));
+            dispatch(runFilter(filterObj));
         }
     }
 };

--- a/public/js/utils/chartList.js
+++ b/public/js/utils/chartList.js
@@ -1,7 +1,7 @@
-export const CHART_ARGS_MAP = {
+export const CHART_FILTERS_MAP = {
   "InWorkflowVsNotInWorkflow": ["startDate", "endDate", "desk", "productionOffice"],
   "ComposerVsIncopy": ["startDate", "endDate", "desk", "productionOffice"],
   "ForkTime": ["startDate", "endDate", "newspaperBook"],
 };
 
-export const CHART_LIST = Object.keys(CHART_ARGS_MAP);
+export const CHART_LIST = Object.keys(CHART_FILTERS_MAP);

--- a/public/js/utils/chartList.js
+++ b/public/js/utils/chartList.js
@@ -1,2 +1,7 @@
-const chartList = ['ComposerVsIncopy', 'InWorkflowVsNotInWorkflow', 'ForkTime'];
-export default chartList;
+export const CHART_ARGS_MAP = {
+  "InWorkflowVsNotInWorkflow": ["startDate", "endDate", "desk", "productionOffice"],
+  "ComposerVsIncopy": ["startDate", "endDate", "desk", "productionOffice"],
+  "ForkTime": ["startDate", "endDate", "newspaperBook"],
+};
+
+export const CHART_LIST = Object.keys(CHART_ARGS_MAP);

--- a/public/styles/components/_chart.scss
+++ b/public/styles/components/_chart.scss
@@ -62,3 +62,10 @@ $loadingLabelHeight: 300px;
 .chart-title--second-series {
   color: $cGreen33;
 }
+
+.no-data {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 1.25rem;
+  padding: 3rem 1rem;
+  text-align: center;
+}


### PR DESCRIPTION
I've made an assumption here: that `timeToPublish` on the `api/forks/` endpoint represents `secondsToFork` in the previous client side code - @susiecoleman is this right?

Things changed:
- `filterDesk` to `runFilter` as it was initially confusing and not the right name
- no longer pass all of the filters to `runFilter`, just a change set so that we can check whats been updated and not update all the APIs that don't depend on that filter
- Added newspaper books fetching / filtering
- Add a little tweak to tidy up when forks has no data

To test this just run it and play around.
  