### PR TITLE
Store dates as strings

### DIFF
--- a/public/js/actions/chartsActions.js
+++ b/public/js/actions/chartsActions.js
@@ -1,33 +1,106 @@
-export const updateComposerVsIncopy = ({ chartData, startDate, endDate }) => ({
-    type: 'UPDATE_COMPOSER_VS_INCOPY',
-    chartData,
-    startDate,
-    endDate
-});
+import moment from 'moment';
+import {
+  createYTotalsList,
+  createPartialsList,
+  formattedSeries,
+  compareDates,
+  compareIssueDates,
+  fillMissingDates
+} from "helpers/chartsHelpers";
+
+
+export const updateComposerVsIncopy = ({ chartData, startDate, endDate }) => {
+    const { composerResponse, inCopyResponse } = chartData;
+    const range = endDate.diff(startDate, 'days');
+    const composerData = composerResponse.data.length <= range ?  fillMissingDates(startDate, endDate, composerResponse.data).sort(compareDates) : composerResponse.data.sort(compareDates);
+    const inCopyData = inCopyResponse.data.length <= range ?  fillMissingDates(startDate, endDate, inCopyResponse.data).sort(compareDates) : inCopyResponse.data.sort(compareDates);
+    const composerVsInCopyData = [{ data: composerData }, { data: inCopyData }];
+
+    const seriesWithLabels = composerVsInCopyData.map(series => {
+        return {
+            data: series.data.map((dataPoint, index) => {
+                const date = moment(dataPoint['date']).utc();
+                return {
+                    x: date.valueOf(),
+                    y: dataPoint['count'],
+                    label: `Date: ${date.format('ddd, Do MMMM YYYY')}\nCreated in Composer: ${composerVsInCopyData[0]['data'][index]['count']}\nCreated in InCopy: ${composerVsInCopyData[1]['data'][index]['count']}`
+                };
+            })
+        };
+    });
+    const totals = createYTotalsList(createPartialsList(seriesWithLabels));
+    const percentSeries = formattedSeries(seriesWithLabels, totals);
+        
+    return {
+        type: 'UPDATE_COMPOSER_VS_INCOPY',
+        absolute: seriesWithLabels,
+        percent: percentSeries
+    };
+};
 
 export const getComposerVsIncopyFailed = (error) => ({
     type: 'GET_COMPOSER_VS_INCOPY_FAILED',
     error
 });
 
-export const updateInWorkflowVsNotInWorkflow = ({ chartData, startDate, endDate }) => ({
-    type: 'UPDATE_IN_WORKFLOW_VS_NOT_IN_WORKFLOW',
-    chartData,
-    startDate,
-    endDate
-});
+export const updateInWorkflowVsNotInWorkflow = ({ chartData, startDate, endDate }) => {
+    const { inWorkflowResponse, notInWorkflowResponse } = chartData;
+    const range = endDate.diff(startDate, 'days');
+    const inWorkflowData = inWorkflowResponse.data.length <= range ?  fillMissingDates(startDate, endDate, inWorkflowResponse.data).sort(compareDates) : inWorkflowResponse.data.sort(compareDates);
+    const notInWorkflowData = notInWorkflowResponse.data.length <= range ?  fillMissingDates(startDate, endDate, notInWorkflowResponse.data).sort(compareDates) : notInWorkflowResponse.data.sort(compareDates);
+    const workflowVsNotInWorkflowData = [{ data: inWorkflowData }, { data: notInWorkflowData }];
+
+    const seriesWithLabels = workflowVsNotInWorkflowData.map(series => {
+        return {
+            data: series.data.map((dataPoint, index) => {
+                const date = moment(dataPoint['date']).utc();
+                return {
+                    x: date.valueOf(),
+                    y: dataPoint['count'],
+                    label: `Date: ${date.format('ddd, Do MMMM YYYY')}\nIn Workflow: ${workflowVsNotInWorkflowData[0]['data'][index]['count']}\nNever in Workflow: ${workflowVsNotInWorkflowData[1]['data'][index]['count']}`
+                };
+            })
+        };
+    });
+    const totals = createYTotalsList(createPartialsList(seriesWithLabels));
+    const percentSeries = formattedSeries(seriesWithLabels, totals);
+
+    return {
+        type: 'UPDATE_IN_WORKFLOW_VS_NOT_IN_WORKFLOW',
+        absolute: seriesWithLabels,
+        percent: percentSeries
+    };
+};
 
 export const getInWorkflowVsNotInWorkflowFailed = (error) => ({
     type: 'GET_IN_WORKFLOW_VS_NOT_IN_WORKFLOW_FAILED',
     error
 });
 
-export const updateForkTime = ({ chartData, startDate, endDate }) => ({
-    type: 'UPDATE_FORK_TIME',
-    chartData,
-    startDate,
-    endDate
-});
+export const updateForkTime = ({ chartData, startDate, endDate }) => {
+
+    const forkTimeData = chartData.data.sort(compareIssueDates);
+    const forkTimeSeries = [{ data: forkTimeData }];
+    const seriesWithLabels = forkTimeSeries.map(series => {
+        return {
+            data: series.data.map((dataPoint) => {
+                const date = moment(dataPoint['issueDate']).utc();
+                const hours = dataPoint.timeToPublication / 3600 / 1000;
+                return {
+                    x: date.valueOf(),
+                    y: hours,
+                    label: `${hours.toFixed(1)} hours`,
+                    size: 2.5
+                };
+            })
+        };
+    });
+
+    return {
+        type: 'UPDATE_FORK_TIME',
+        absolute: seriesWithLabels
+    };
+};
 
 export const getForkTimeFailed = (error) => ({
     type: 'GET_FORK_TIME_FAILED',

--- a/public/js/actions/index.js
+++ b/public/js/actions/index.js
@@ -17,6 +17,7 @@ import {
   getNewspaperBooksFailed
 } from "./filtersActions";
 import api from 'services/Api';
+import moment from "moment";
 
 const chartsActions = { 
     updateComposerVsIncopy,
@@ -59,7 +60,9 @@ export const runFilter = (filterChangeset = {}) => {
         const updatedFilters = { ...filterVals, ...filterChangeset };
         dispatch(updateFilter(updatedFilters));
         dispatch(toggleIsUpdatingCharts(true));
-        const { startDate, endDate } = updatedFilters;
+        
+        const startDate = moment(updatedFilters.startDate);
+        const endDate = moment(updatedFilters.endDate);
         CHART_LIST
             .filter(chart => chartNeedsUpdate(chart, filterChangeset))
             .map(chart => {

--- a/public/js/components/Filters/Filters.js
+++ b/public/js/components/Filters/Filters.js
@@ -68,7 +68,15 @@ export default class Filters extends Component {
                                             disabled={isUpdating}
                                             startDate={filterVals.startDate}
                                             endDate={filterVals.endDate}
-                                            onDatesChange={({ startDate, endDate }) => endDate > startDate ? runFilter({ ...filterVals, startDate: startDate.utc().startOf('day'), endDate: endDate.utc().endOf('day') }) : false }
+                                            onDatesChange={
+                                                ({ startDate, endDate }) =>
+                                                    endDate > startDate ?
+                                                        runFilter({
+                                                            startDate: startDate.utc().startOf('day').format(),
+                                                            endDate: endDate.utc().endOf('day').format()
+                                                        }) :
+                                                        false
+                                            }
                                             focusedInput={this.state.focusedInput}
                                             onFocusChange={focusedInput => this.setState({ focusedInput })}
                                             isOutsideRange={(day) => day.isAfter(moment())}

--- a/public/js/containers/App.js
+++ b/public/js/containers/App.js
@@ -5,6 +5,7 @@ import actions from 'actions';
 import Page from 'components/Page';
 import Filters from 'components/Filters/Filters';
 import Charts from 'components/Charts/Charts';
+import { getFilters } from "../selectors";
 
 class App extends Component {
     componentDidMount() {
@@ -42,9 +43,10 @@ const mapDispatchToProps = (dispatch) => ({
 });
 
 const mapStateToProps = (state) => {
-    const { filterVals, charts, isUpdating, commissioningDesks, newspaperBooks } = state;
+    const { charts, isUpdating, commissioningDesks, newspaperBooks } = state;
+    
     return {
-        filterVals,
+        filterVals: getFilters(state),
         charts,
         isUpdating,
         commissioningDesks,

--- a/public/js/reducers/chartsReducer.js
+++ b/public/js/reducers/chartsReducer.js
@@ -1,6 +1,3 @@
-import { createYTotalsList, createPartialsList, formattedSeries, compareDates, compareIssueDates, fillMissingDates } from 'helpers/chartsHelpers';
-import moment from 'moment';
-
 const initialState = {
     composerVsInCopy: {
         data: {
@@ -24,37 +21,17 @@ const initialState = {
 };
 
 const charts = (state = initialState, action) => {
-    const { type, chartData, startDate, endDate, error, isStacked } = action;
+    const { type, absolute, percent, error, isStacked } = action;
     switch (type) {
     case 'UPDATE_COMPOSER_VS_INCOPY': {
-        const { composerResponse, inCopyResponse } = chartData;
-        const range = endDate.diff(startDate, 'days');
-        const composerData = composerResponse.data.length <= range ?  fillMissingDates(startDate, endDate, composerResponse.data).sort(compareDates) : composerResponse.data.sort(compareDates);
-        const inCopyData = inCopyResponse.data.length <= range ?  fillMissingDates(startDate, endDate, inCopyResponse.data).sort(compareDates) : inCopyResponse.data.sort(compareDates);
-        const composerVsInCopyData = [{ data: composerData }, { data: inCopyData }];
-
-        const seriesWithLabels = composerVsInCopyData.map(series => {
-            return {
-                data: series.data.map((dataPoint, index) => {
-                    const date = moment(dataPoint['date']).utc();
-                    return {
-                        x: date.valueOf(),
-                        y: dataPoint['count'],
-                        label: `Date: ${date.format('ddd, Do MMMM YYYY')}\nCreated in Composer: ${composerVsInCopyData[0]['data'][index]['count']}\nCreated in InCopy: ${composerVsInCopyData[1]['data'][index]['count']}`
-                    };
-                })
-            };
-        });
-        const totals = createYTotalsList(createPartialsList(seriesWithLabels));
-        const percentSeries = formattedSeries(seriesWithLabels, totals);
         return {
             ...state,
             composerVsInCopy: {
+                ...state.composerVsInCopy,
                 data: {
-                    absolute: seriesWithLabels,
-                    percent: percentSeries
-                },
-                isStacked: state.composerVsInCopy.isStacked
+                    absolute,
+                    percent
+                }
             }
         };
     }
@@ -65,35 +42,14 @@ const charts = (state = initialState, action) => {
         return Object.assign({}, state, { composerVsInCopy: { ...state.composerVsInCopy, isStacked }});
 
     case 'UPDATE_IN_WORKFLOW_VS_NOT_IN_WORKFLOW': {
-        const { inWorkflowResponse, notInWorkflowResponse } = chartData;
-        const range = endDate.diff(startDate, 'days');
-        const inWorkflowData = inWorkflowResponse.data.length <= range ?  fillMissingDates(startDate, endDate, inWorkflowResponse.data).sort(compareDates) : inWorkflowResponse.data.sort(compareDates);
-        const notInWorkflowData = notInWorkflowResponse.data.length <= range ?  fillMissingDates(startDate, endDate, notInWorkflowResponse.data).sort(compareDates) : notInWorkflowResponse.data.sort(compareDates);
-        const workflowVsNotInWorkflowData = [{ data: inWorkflowData }, { data: notInWorkflowData }];
-
-        const seriesWithLabels = workflowVsNotInWorkflowData.map(series => {
-            return {
-                data: series.data.map((dataPoint, index) => {
-                    const date = moment(dataPoint['date']).utc();
-                    return {
-                        x: date.valueOf(),
-                        y: dataPoint['count'],
-                        label: `Date: ${date.format('ddd, Do MMMM YYYY')}\nIn Workflow: ${workflowVsNotInWorkflowData[0]['data'][index]['count']}\nNever in Workflow: ${workflowVsNotInWorkflowData[1]['data'][index]['count']}`
-                    };
-                })
-            };
-        });
-        const totals = createYTotalsList(createPartialsList(seriesWithLabels));
-        const percentSeries = formattedSeries(seriesWithLabels, totals);
-
         return {
             ...state,
             inWorkflowVsNotInWorkflow: {
+                ...state.inWorkflowVsNotInWorkflow,
                 data: {
-                    absolute: seriesWithLabels,
-                    percent: percentSeries
-                },
-                isStacked: state.inWorkflowVsNotInWorkflow.isStacked
+                    absolute,
+                    percent
+                }
             }
         };  
     }
@@ -101,27 +57,11 @@ const charts = (state = initialState, action) => {
         return Object.assign({}, state, { inWorkflowVsNotInWorkflow: { ...state.inWorkflowVsNotInWorkflow, error }});
         
     case 'UPDATE_FORK_TIME': {
-        const forkTimeData = chartData.data.sort(compareIssueDates);
-        const forkTimeSeries = [{ data: forkTimeData }];
-        const seriesWithLabels = forkTimeSeries.map(series => {
-            return {
-                data: series.data.map((dataPoint) => {
-                    const date = moment(dataPoint['issueDate']).utc();
-                    const hours = dataPoint.timeToPublication / 3600 / 1000;
-                    return {
-                        x: date.valueOf(),
-                        y: hours,
-                        label: `${hours.toFixed(1)} hours`,
-                        size: 2.5
-                    };
-                })
-            };
-        });
         return {
             ...state,
             forkTime: {
                 data: {
-                    absolute: seriesWithLabels
+                    absolute
                 }
             }
         };

--- a/public/js/reducers/updateFilterReducer.js
+++ b/public/js/reducers/updateFilterReducer.js
@@ -6,8 +6,8 @@ const initialState = {
     desk: 'tracking/commissioningdesk/all',
     newspaperBook: 'theguardian/main', // TODO: set this programatically
     productionOffice: 'all',
-    startDate: getYesterday().startOf('day').subtract(7,'d'),
-    endDate: getYesterday().endOf('day')
+    startDate: getYesterday().startOf('day').subtract(7,'d').format(),
+    endDate: getYesterday().endOf('day').format()
 };
 
 const filterVals = (state = initialState, action) => {

--- a/public/js/selectors/index.js
+++ b/public/js/selectors/index.js
@@ -1,0 +1,9 @@
+import moment from "moment";
+import memoize from "lodash/memoize";
+
+// If the state object is the same then just return the same obj
+export const getFilters = memoize(({ filterVals }) => ({
+  ...filterVals,
+  startDate: moment(filterVals.startDate),
+  endDate: moment(filterVals.endDate),
+}));

--- a/public/js/services/Api.js
+++ b/public/js/services/Api.js
@@ -3,8 +3,8 @@ import { pandaFetch } from './pandaFetch';
 
 const buildQueryParams = (startDate, endDate, desk, productionOffice) => ({
     params: {
-        startDate: startDate.format(),
-        endDate: endDate.format(),
+        startDate: startDate,
+        endDate: endDate,
         desk: desk !== 'tracking/commissioningdesk/all' && desk || null,
         productionOffice: productionOffice !== 'all' && productionOffice || null
     }

--- a/public/js/services/routingMiddleware.js
+++ b/public/js/services/routingMiddleware.js
@@ -8,7 +8,11 @@ export const updateUrlFromStateChangeMiddleware = ({ dispatch, getState }) => (n
     let result = next(action);
     const newState = getState();
     // this formatting is needed as the dates in the state are moment objects, but need to be strings in the url
-    const newStateFormattedFilters = { ...newState.filterVals,  startDate: newState.filterVals.startDate.format(), endDate: newState.filterVals.endDate.format() };
+    const newStateFormattedFilters = {
+        ...newState.filterVals,
+        startDate: newState.filterVals.startDate,
+        endDate: newState.filterVals.endDate
+    };
 
     if (!_isEqual(prevState.filterVals, newState.filterVals)) {
         const location = newState.routing.location;
@@ -30,12 +34,6 @@ export const updateStateFromUrlChangeMiddleware = ({ dispatch, getState }) => (n
 
     if (action.type === '@@router/LOCATION_CHANGE') {
         const filterObj = paramStringToObject(newState.routing.location.search);
-        if(filterObj.startDate) {
-            filterObj.startDate = moment(filterObj.startDate);
-        }
-        if(filterObj.endDate) {
-            filterObj.endDate = moment(filterObj.endDate);
-        }
 
         const nextFilterVals = {
             ...newState.filterVals,


### PR DESCRIPTION
None string dates where causing problems where we were comparing filters for deep equality, which would require traversing the whole of a `moment` object. And when using `===` equal dates would return `false`.