### PR TITLE
filter fork data by fork time

### DIFF
--- a/app/database/MetricsDB.scala
+++ b/app/database/MetricsDB.scala
@@ -38,7 +38,7 @@ class MetricsDB(implicit val db: Database) {
     awaitWithTransformation(db.run(
       forksTable.map(f => (f.composerId, f.timeToPublication, f.time))
         .join(metricsTable).on(_._1 === _.composerId)
-        .filter(MetricsFilters.forksFilters)
+        .filter(MetricsFilters.forkFilters)
         .map { case ((_, timeToPublication, forkTime), _) => (timeToPublication, forkTime.toDayDateTrunc) }
         .result)
     )(_.flatMap(ForkResponse.convertToForkResponse).toList)

--- a/app/database/MetricsDB.scala
+++ b/app/database/MetricsDB.scala
@@ -36,12 +36,12 @@ class MetricsDB(implicit val db: Database) {
 
   def getForks(implicit filters: MetricsFilters): Either[ProductionMetricsError, List[ForkResponse]] =
     awaitWithTransformation(db.run(
-      forksTable.map(f => (f.composerId, f.timeToPublication))
+      forksTable.map(f => (f.composerId, f.timeToPublication, f.time))
         .join(metricsTable).on(_._1 === _.composerId)
         .filter(MetricsFilters.forksFilters)
-        .map { case ((composerId, timeToPublication), metric) => (timeToPublication, metric.issueDate.toDayDateTrunc) }
+        .map { case ((_, timeToPublication, forkTime), _) => (timeToPublication, forkTime.toDayDateTrunc) }
         .result)
-      )(_.flatMap(ForkResponse.convertToForkResponse).toList)
+    )(_.flatMap(ForkResponse.convertToForkResponse).toList)
 
   def insertFork(fork: Fork): Either[ProductionMetricsError, Int] = await(db.run(forksTable += fork))
 

--- a/app/models/db/MetricsFilters.scala
+++ b/app/models/db/MetricsFilters.scala
@@ -71,10 +71,10 @@ object MetricsFilters {
 
   def metricFilters(implicit filters: MetricsFilters): DBMetric => Rep[Option[Boolean]] = metric => checkMetricsFilters(metric)
 
-  def forksFilters(implicit filters: MetricsFilters): ((ForkFilterColumns, DBMetric)) => Rep[Option[Boolean]] = forkAndMetric =>
-    checkMetricsForkingFilters(forkAndMetric)
+  def forkFilters(implicit filters: MetricsFilters): ((ForkFilterColumns, DBMetric)) => Rep[Option[Boolean]] = forkAndMetric =>
+    checkMetricsForkFilters(forkAndMetric)
 
-  private def checkMetricsForkingFilters(data: (ForkFilterColumns, Schema.DBMetric))(implicit filters: MetricsFilters): Rep[Option[Boolean]] = {
+  private def checkMetricsForkFilters(data: (ForkFilterColumns, Schema.DBMetric))(implicit filters: MetricsFilters): Rep[Option[Boolean]] = {
     val (fork, metric) = data
     filters.dateRange.fold(TrueOptCol)(dr => fork._3.? >= dr.from && fork._3.? <= dr.to) &&
       checkCommonFilters(metric)

--- a/app/models/db/MetricsFilters.scala
+++ b/app/models/db/MetricsFilters.scala
@@ -25,6 +25,9 @@ case class MetricsFilters(
 )
 
 object MetricsFilters {
+
+  type ForkFilterColumns = (Rep[String], Rep[Option[Int]], Rep[DateTime])
+
   private val TrueOptCol: Rep[Option[Boolean]] = LiteralColumn(Some(true))
 
   def apply(queryString: Map[String, Seq[String]]): MetricsFilters =
@@ -68,16 +71,27 @@ object MetricsFilters {
 
   def metricFilters(implicit filters: MetricsFilters): DBMetric => Rep[Option[Boolean]] = metric => checkMetricsFilters(metric)
 
-  def forksFilters[T](implicit filters: MetricsFilters): ((T, DBMetric)) => Rep[Option[Boolean]] = forkAndMetric => checkMetricsFilters(forkAndMetric._2)
+  def forksFilters(implicit filters: MetricsFilters): ((ForkFilterColumns, DBMetric)) => Rep[Option[Boolean]] = forkAndMetric =>
+    checkMetricsForkingFilters(forkAndMetric)
+
+  private def checkMetricsForkingFilters(data: (ForkFilterColumns, Schema.DBMetric))(implicit filters: MetricsFilters): Rep[Option[Boolean]] = {
+    val (fork, metric) = data
+    filters.dateRange.fold(TrueOptCol)(dr => fork._3.? >= dr.from && fork._3.? <= dr.to) &&
+      checkCommonFilters(metric)
+  }
 
   private def checkMetricsFilters(metric: Schema.DBMetric)(implicit filters: MetricsFilters): Rep[Option[Boolean]] = {
+    filters.dateRange.fold(TrueOptCol)(dr => metric.creationTime.? >= dr.from && metric.creationTime.? <= dr.to) &&
+      checkCommonFilters(metric)
+  }
+
+  private def checkCommonFilters(metric: Schema.DBMetric)(implicit filters: MetricsFilters): Rep[Option[Boolean]] = {
     import MetricHelpers._
     filters.desk.fold(TrueOptCol)(d => metric.commissioningDesk.toLowerCase === d.toLowerCase) &&
-    filters.originatingSystem.fold(TrueOptCol)(os => metric.originatingSystem.? === os) &&
-    filters.dateRange.fold(TrueOptCol)(dr => metric.creationTime.? >= dr.from && metric.creationTime.? <= dr.to) &&
-    filters.productionOffice.fold(TrueOptCol)(po => metric.productionOffice === po) &&
-    filters.inWorkflow.fold(TrueOptCol)(inWf => metric.inWorkflow.? === inWf) &&
-    filters.newspaperBook.fold(TrueOptCol)(nb => metric.newspaperBook.toLowerCase === nb.toLowerCase)
+      filters.originatingSystem.fold(TrueOptCol)(os => metric.originatingSystem.? === os) &&
+      filters.productionOffice.fold(TrueOptCol)(po => metric.productionOffice === po) &&
+      filters.inWorkflow.fold(TrueOptCol)(inWf => metric.inWorkflow.? === inWf) &&
+      filters.newspaperBook.fold(TrueOptCol)(nb => metric.newspaperBook.toLowerCase === nb.toLowerCase)
   }
 }
 
@@ -95,9 +109,10 @@ case class ForkResponse(issueDate: DateTime, timeToPublication: Int)
 
 object ForkResponse {
 
-  def convertToForkResponse(pair : (Option[Int], Option[DateTime])) =
-    for {
-      timeToPublication <- pair._1
-      issueDate <- pair._2
-    } yield ForkResponse(issueDate, timeToPublication)
+  def convertToForkResponse(pair : (Option[Int], DateTime)) = {
+
+    val (timeToPublicationOpt, forkTime) = pair
+
+    timeToPublicationOpt.map(timeToPublication => ForkResponse(forkTime, timeToPublication))
+  }
 }

--- a/test-integration/controllers/MetricsDBSpec.scala
+++ b/test-integration/controllers/MetricsDBSpec.scala
@@ -63,11 +63,11 @@ class MetricsDBSpec extends FunSuite with MockitoSugar with Matchers with Result
     val getInitialForks = metricsDb.getForks(MetricsFilters())
     getInitialForks shouldBe a [Right[_,_]]
 
-    TestData.addMetric(TestData.randomMetricWith("composerId_fork1", "storyBundleId_fork1").copy(commissioningDesk = Some("testFilters"), issueDate = Some(new DateTime("2017-01-01"))))
-    TestData.addFork(TestData.randomForkWith("composerId_fork1").copy(timeToPublication = Some(1234)))
+    TestData.addMetric(TestData.randomMetricWith("composerId_fork1", "storyBundleId_fork1").copy(commissioningDesk = Some("testFilters")))
+    TestData.addFork(TestData.randomForkWith("composerId_fork1", new DateTime("2017-01-01")).copy(timeToPublication = Some(1234)))
 
-    TestData.addMetric(TestData.randomMetricWith("composerId_fork2", "storyBundleId_fork2").copy(commissioningDesk = Some("testFilters"), issueDate = Some(new DateTime("2017-11-11"))))
-    TestData.addFork(TestData.randomForkWith("composerId_fork2").copy(timeToPublication = Some(4321)))
+    TestData.addMetric(TestData.randomMetricWith("composerId_fork2", "storyBundleId_fork2").copy(commissioningDesk = Some("testFilters")))
+    TestData.addFork(TestData.randomForkWith("composerId_fork2", new DateTime("2017-11-11")).copy(timeToPublication = Some(4321)))
 
     val getFilteredForks = metricsDb.getForks(MetricsFilters(desk = Some("testFilters")))
     getFilteredForks shouldBe a [Right[_,_]]

--- a/test-integration/helpers/TestData.scala
+++ b/test-integration/helpers/TestData.scala
@@ -71,7 +71,7 @@ object TestData {
   def randomMetricWith(composerId: String, storyBundleId: String): Metric =
     generateRandomMetric(0).copy(composerId = Some(composerId), storyBundleId = Some(storyBundleId))
 
-  def randomForkWith(composerId: String) = generateRandomFork.copy(composerId = composerId)
+  def randomForkWith(composerId: String, time: DateTime) = generateRandomFork.copy(composerId = composerId, time = time)
 
   private[this] def randomMetrics(acc: List[Metric], size: Int): List[Metric] =
     if (size == 0) acc else randomMetrics(generateRandomMetric(size) :: acc, size - 1)


### PR DESCRIPTION
Instead of filtering fork data by creation time, filter it by the fork date. On the client we then display the fork date of the article vs. the time it took to publish the article. 