### PR TITLE
Use classnames package for simpler classes

### DIFF
--- a/public/js/components/Charts/Chart.js
+++ b/public/js/components/Charts/Chart.js
@@ -1,20 +1,14 @@
 import React from 'react';
+import cx from "classnames";
 
-const getClassName = (error, isUpdating) => {
-    if (error) {
-        return 'chart-wrap chart-wrap__error';
-    } else {
-        return isUpdating ? 'chart-wrap chart-wrap__updating' : 'chart-wrap';
-    }
-};
-
-const Chart = ({children, error, isUpdating}) => {
-
-    return (
-        <div className={getClassName(error, isUpdating)}>
-            {children}
-        </div>
-    );
-};
+const Chart = ({children, error, isUpdating}) => (
+    <div className={cx({
+        "chart-wrap": true,
+        "chart-wrap__error": error,
+        "chart-wrap__updating": isUpdating
+    })}>
+        {children}
+    </div>
+);
 
 export default Chart;

--- a/public/js/components/Table/Table.js
+++ b/public/js/components/Table/Table.js
@@ -1,14 +1,6 @@
 import React from "react";
 import { Th } from './index';
-
-const tableClass = centered =>
-  [
-    "table",
-    centered ? `table--centered` : ""
-  ]
-    .join(" ")
-    .replace(/\s+/, " ")
-    .trim();
+import cx from "classnames";
 
 const renderSection = (leftTitle, children, propFn) =>
   React.Children.map(children, (child, index) =>
@@ -26,7 +18,10 @@ const renderSection = (leftTitle, children, propFn) =>
   );
 
 const Table = ({ head, children, centered, headTitle, bodyTitle, alternate }) => (
-  <table className={tableClass(centered)}>
+  <table className={cx({
+    table: true,
+    "table--centered": centered,
+  })}>
     {head && (
       <thead className="table__head">
         {renderSection(headTitle, head, () => ({ headerRow: true }))}

--- a/public/js/components/Table/Tr.js
+++ b/public/js/components/Table/Tr.js
@@ -1,14 +1,14 @@
 import React from "react";
-
-const baseClass = headerRow => `table__${headerRow ? `header-` : ""}row`;
+import cx from "classnames";
 
 const Tr = ({ children, headerRow, isOdd, ...trProps }) => (
   <tr
-    className={`${baseClass(headerRow)} ${
-      isOdd !== null
-        ? `${baseClass(headerRow)}--${isOdd ? "odd" : "even"}`
-        : ``
-    }`}
+    className={cx({
+      "table__row": true,
+      "table__row--header": headerRow,
+      "table__row--odd": isOdd,
+      "table__row--even": !isOdd,
+    })}
     {...trProps}
   >
     {children}

--- a/public/styles/components/_tables.scss
+++ b/public/styles/components/_tables.scss
@@ -40,7 +40,7 @@
       background: $lightBrandColor;
     }
 
-    &:hover {
+    &:hover:not(.table__row--header) {
       background-color: $color500Grey;
 
       & + & {
@@ -53,19 +53,19 @@
         border-top: 1px solid $color650Grey;
       }
     }
-  }
 
-  &__header-row {
-    background: $color650Grey;
-    border: {
-      bottom: 1px solid $cYellow;
-    };
-    font-size: 13px;
-    font-weight: bold;
+    &--header {
+      background: $color650Grey;
+      border: {
+        bottom: 1px solid $cYellow;
+      };
+      font-size: 13px;
+      font-weight: bold;
 
-    & + & {
-      .table__item {
-        border-top: 1px solid $color700Grey;
+      & + & {
+        .table__item {
+          border-top: 1px solid $color700Grey;
+        }
       }
     }
   }


### PR DESCRIPTION
Now using [`classname`]https://www.npmjs.com/package/classnames) package for dynamic classnames as it's easier to use, clearer to read and very small.

N.b. these is a bit of a community idiom of importing it as `cx` but obviously that isn't necessary.