### PR TITLE
Bump SBT version and fix IntelliJ import

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import com.typesafe.sbt.packager.archetypes.ServerLoader.Systemd
 name := "editorial-production-metrics"
 version := "1.0"
 
-scalaVersion := "2.11.11"
+scalaVersion in ThisBuild := "2.11.11"
 
 resolvers ++= Seq("Guardian Bintray" at "https://dl.bintray.com/guardian/editorial-tools")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.16


### PR DESCRIPTION
The latest IntelliJ was going wonky importing the project. I think it might be something related to having both play and sub-projects. (Maybe https://github.com/sbt/sbt/issues/3353?).

I fixed it by bumping SBT to the latest `0.13.x` release and adding `in ThisBuild` to the `scalaVersion` definition, copying what we have in PFI. :man_shrugging: 