### PR TITLE
Add wordcount, commissioned wordcount and path to database

### DIFF
--- a/app/kinesis/ProductionMetricsIndexStreamReader.scala
+++ b/app/kinesis/ProductionMetricsIndexStreamReader.scala
@@ -81,7 +81,10 @@ object ProductionMetricsStreamReader {
           creationTime = Some(creationDate),
           firstPublicationTime = Some(firstPublicationDate),
           inNewspaper = Some(capiData.newspaperBookTag.isDefined),
-          productionOffice = capiData.productionOffice)
+          productionOffice = capiData.productionOffice,
+          commissionedWordCount = capiData.commissionedWordCount,
+          path = Some(capiData.path),
+          wordCount = capiData.wordCount)
       } yield db.updateOrInsert(existingMetric, metric)).getOrElse(Left(UnexpectedExceptionError))
   }
 }

--- a/app/models/db/Metrics.scala
+++ b/app/models/db/Metrics.scala
@@ -31,7 +31,10 @@ case class Metric(
    bookSectionName: Option[String] = None,
    bookSectionCode: Option[String] = None,
    newspaperBook: Option[String] = None,
-   newspaperBookSection: Option[String] = None)
+   newspaperBookSection: Option[String] = None,
+   path: Option[String] = None,
+   wordCount: Option[Int] = None,
+   commissionedWordCount: Option[Int] = None)
 
 object Metric {
   def apply(metricOpt: MetricOpt): Metric = Metric(
@@ -51,7 +54,10 @@ object Metric {
     bookSectionName = metricOpt.bookSectionName,
     bookSectionCode = metricOpt.bookSectionCode,
     newspaperBook = metricOpt.newspaperBook,
-    newspaperBookSection = metricOpt.newspaperBookSection
+    newspaperBookSection = metricOpt.newspaperBookSection,
+    path = metricOpt.path,
+    wordCount = metricOpt.wordCount,
+    commissionedWordCount = metricOpt.commissionedWordCount
   )
 
   private val datePattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
@@ -73,7 +79,10 @@ object Metric {
       Option[String],
       Option[String],
       Option[String],
-      Option[String])
+      Option[String],
+      Option[String],
+      Option[Int],
+      Option[Int])
    ): Metric =
     Metric(
       id = tuple._1,
@@ -92,7 +101,11 @@ object Metric {
       bookSectionName = tuple._14,
       bookSectionCode = tuple._15,
       newspaperBook = tuple._16,
-      newspaperBookSection = tuple._17)
+      newspaperBookSection = tuple._17,
+      path = tuple._18,
+      wordCount = tuple._19,
+      commissionedWordCount = tuple._20
+    )
 
   implicit val timeEncoder = new Encoder[DateTime] {
     def apply(d: DateTime) = d.toString(datePattern).asJson

--- a/app/models/db/Schema.scala
+++ b/app/models/db/Schema.scala
@@ -30,6 +30,9 @@ object Schema {
     def bookSectionCode       = column[Option[String]]("book_section_code")
     def newspaperBook         = column[Option[String]]("newspaper_book")
     def newspaperBookSection  = column[Option[String]]("newspaper_book_section")
+    def path                  = column[Option[String]]("path")
+    def wordCount             = column[Option[Int]]("word_count")
+    def commissionedWordCount = column[Option[Int]]("commissioned_word_count")
     def * = (
       id,
       originatingSystem,
@@ -47,7 +50,10 @@ object Schema {
       bookSectionName,
       bookSectionCode,
       newspaperBook,
-      newspaperBookSection) <> (Metric.customApply _, Metric.unapply _)
+      newspaperBookSection,
+      path,
+      wordCount,
+      commissionedWordCount) <> (Metric.customApply _, Metric.unapply _)
   }
 
   class DBFork(tag: Tag) extends Table[Fork](tag, "forks") {

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ lazy val sharedDependencies = Seq(
   "io.circe"               %% "circe-parser"                     % "0.8.0",
   "io.circe"               %% "circe-generic"                    % "0.8.0",
   "com.beachape"           %% "enumeratum-circe"                 % "1.5.14",
-  "com.gu"                 %% "editorial-production-metrics-lib" % "0.15"
+  "com.gu"                 %% "editorial-production-metrics-lib" % "0.16"
 )
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, RiffRaffArtifact, JDebPackaging)


### PR DESCRIPTION
The build should pass once the new version of the production metrics has been released. 
See: https://github.com/guardian/editorial-production-metrics-lib/pull/14
  