### PR TITLE
Add chart selectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "redux": "^3.6.0",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.2.0",
+    "reselect": "^3.0.1",
     "victory": "^0.21.2"
   }
 }

--- a/public/js/actions/chartsActions.js
+++ b/public/js/actions/chartsActions.js
@@ -1,108 +1,33 @@
-import moment from 'moment';
-import {
-  createYTotalsList,
-  createPartialsList,
-  formattedSeries,
-  compareDates,
-  compareIssueDates,
-  fillMissingDates
-} from "helpers/chartsHelpers";
-
-
-export const updateComposerVsIncopy = ({ chartData, startDate, endDate }) => {
-    const { composerResponse, inCopyResponse } = chartData;
-    const range = endDate.diff(startDate, 'days');
-    const composerData = composerResponse.data.length <= range ?  fillMissingDates(startDate, endDate, composerResponse.data).sort(compareDates) : composerResponse.data.sort(compareDates);
-    const inCopyData = inCopyResponse.data.length <= range ?  fillMissingDates(startDate, endDate, inCopyResponse.data).sort(compareDates) : inCopyResponse.data.sort(compareDates);
-    const composerVsInCopyData = [{ data: composerData }, { data: inCopyData }];
-
-    const seriesWithLabels = composerVsInCopyData.map(series => {
-        return {
-            data: series.data.map((dataPoint, index) => {
-                const date = moment(dataPoint['date']).utc();
-                return {
-                    x: date.valueOf(),
-                    y: dataPoint['count'],
-                    label: `Date: ${date.format('ddd, Do MMMM YYYY')}\nCreated in Composer: ${composerVsInCopyData[0]['data'][index]['count']}\nCreated in InCopy: ${composerVsInCopyData[1]['data'][index]['count']}`
-                };
-            })
-        };
-    });
-    const totals = createYTotalsList(createPartialsList(seriesWithLabels));
-    const percentSeries = formattedSeries(seriesWithLabels, totals);
-        
-    return {
-        type: 'UPDATE_COMPOSER_VS_INCOPY',
-        absolute: seriesWithLabels,
-        percent: percentSeries
-    };
-};
-
-export const getComposerVsIncopyFailed = (error) => ({
-    type: 'GET_COMPOSER_VS_INCOPY_FAILED',
-    error
+const updateChartData = type => (chartData, startDate, endDate) => ({
+    type,
+    payload: {
+        chartData,
+        startDate,
+        endDate
+    }
 });
 
-export const updateInWorkflowVsNotInWorkflow = ({ chartData, startDate, endDate }) => {
-    const { inWorkflowResponse, notInWorkflowResponse } = chartData;
-    const range = endDate.diff(startDate, 'days');
-    const inWorkflowData = inWorkflowResponse.data.length <= range ?  fillMissingDates(startDate, endDate, inWorkflowResponse.data).sort(compareDates) : inWorkflowResponse.data.sort(compareDates);
-    const notInWorkflowData = notInWorkflowResponse.data.length <= range ?  fillMissingDates(startDate, endDate, notInWorkflowResponse.data).sort(compareDates) : notInWorkflowResponse.data.sort(compareDates);
-    const workflowVsNotInWorkflowData = [{ data: inWorkflowData }, { data: notInWorkflowData }];
-
-    const seriesWithLabels = workflowVsNotInWorkflowData.map(series => {
-        return {
-            data: series.data.map((dataPoint, index) => {
-                const date = moment(dataPoint['date']).utc();
-                return {
-                    x: date.valueOf(),
-                    y: dataPoint['count'],
-                    label: `Date: ${date.format('ddd, Do MMMM YYYY')}\nIn Workflow: ${workflowVsNotInWorkflowData[0]['data'][index]['count']}\nNever in Workflow: ${workflowVsNotInWorkflowData[1]['data'][index]['count']}`
-                };
-            })
-        };
-    });
-    const totals = createYTotalsList(createPartialsList(seriesWithLabels));
-    const percentSeries = formattedSeries(seriesWithLabels, totals);
-
-    return {
-        type: 'UPDATE_IN_WORKFLOW_VS_NOT_IN_WORKFLOW',
-        absolute: seriesWithLabels,
-        percent: percentSeries
-    };
-};
-
-export const getInWorkflowVsNotInWorkflowFailed = (error) => ({
-    type: 'GET_IN_WORKFLOW_VS_NOT_IN_WORKFLOW_FAILED',
-    error
+const chartDataRequestFailed = type => error => ({
+    type,
+    payload: {
+        error
+    }
 });
 
-export const updateForkTime = ({ chartData, startDate, endDate }) => {
+/* UPDATES */
+export const updateComposerVsIncopy = updateChartData(
+    "UPDATE_COMPOSER_VS_INCOPY"
+);
+export const updateInWorkflowVsNotInWorkflow = updateChartData(
+    "UPDATE_IN_WORKFLOW_VS_NOT_IN_WORKFLOW"
+);
+export const updateForkTime = updateChartData("UPDATE_FORK_TIME");
 
-    const forkTimeData = chartData.data.sort(compareIssueDates);
-    const forkTimeSeries = [{ data: forkTimeData }];
-    const seriesWithLabels = forkTimeSeries.map(series => {
-        return {
-            data: series.data.map((dataPoint) => {
-                const date = moment(dataPoint['issueDate']).utc();
-                const hours = dataPoint.timeToPublication / 3600 / 1000;
-                return {
-                    x: date.valueOf(),
-                    y: hours,
-                    label: `${hours.toFixed(1)} hours`,
-                    size: 2.5
-                };
-            })
-        };
-    });
-
-    return {
-        type: 'UPDATE_FORK_TIME',
-        absolute: seriesWithLabels
-    };
-};
-
-export const getForkTimeFailed = (error) => ({
-    type: 'GET_FORK_TIME_FAILED',
-    error
-});
+/* FAILURES */
+export const getComposerVsIncopyFailed = chartDataRequestFailed(
+    "GET_COMPOSER_VS_INCOPY_FAILED"
+);
+export const getInWorkflowVsNotInWorkflowFailed = chartDataRequestFailed(
+    "GET_IN_WORKFLOW_VS_NOT_IN_WORKFLOW_FAILED"
+);
+export const getForkTimeFailed = chartDataRequestFailed("GET_FORK_TIME_FAILED");

--- a/public/js/actions/index.js
+++ b/public/js/actions/index.js
@@ -17,7 +17,6 @@ import {
   getNewspaperBooksFailed
 } from "./filtersActions";
 import api from 'services/Api';
-import moment from "moment";
 
 const chartsActions = { 
     updateComposerVsIncopy,
@@ -32,7 +31,7 @@ const chartsActions = {
 
 const updateAttemptActions = (chartData, chart, startDate, endDate, dispatch) => {
     dispatch(toggleIsUpdatingCharts(false));
-    dispatch(chartsActions[`update${chart}`]({ chartData, startDate, endDate }));
+    dispatch(chartsActions[`update${chart}`](chartData, startDate, endDate));
 };
 
 const responseFailActions = (chart, error, dispatch) => {
@@ -61,8 +60,7 @@ export const runFilter = (filterChangeset = {}) => {
         dispatch(updateFilter(updatedFilters));
         dispatch(toggleIsUpdatingCharts(true));
         
-        const startDate = moment(updatedFilters.startDate);
-        const endDate = moment(updatedFilters.endDate);
+        const { startDate, endDate } = updatedFilters;
         CHART_LIST
             .filter(chart => chartNeedsUpdate(chart, filterChangeset))
             .map(chart => {
@@ -98,7 +96,9 @@ export const fetchNewspaperBooks = () => {
 
 export const toggleStackChart = (isStacked) => ({
     type: 'TOGGLE_STACK_CHART',
-    isStacked
+    payload: {
+        isStacked
+    }
 });
 
 export const updateFilterStatuses = statuses => ({

--- a/public/js/containers/App.js
+++ b/public/js/containers/App.js
@@ -5,8 +5,9 @@ import actions from "actions";
 import Page from "components/Page";
 import Filters from "components/Filters/Filters";
 import { getFilters } from "../selectors";
-import Origin from "components/Tabs/Origin";
+import OriginData from "./OriginData";
 import CommissionedLengthData from "./CommissionedLengthData";
+import ForkTimeData from "./ForkTimeData";
 import ForkTime from "../components/Tabs/ForkTime";
 import {
     TabLink,
@@ -29,7 +30,6 @@ class App extends Component {
             filterVals,
             filterStatuses,
             isUpdating,
-            charts,
             commissioningDesks,
             newspaperBooks,
             actions
@@ -61,22 +61,13 @@ class App extends Component {
                             path="/origin"
                             disabledFilters={[ "newspaperBook" ]}
                         >
-                            <Origin
-                                filterVals={filterVals}
-                                isUpdating={isUpdating}
-                                charts={charts}
-                                toggleStackChart={actions.toggleStackChart}
-                            />
+                            <OriginData />
                         </TabRoute>
                         <TabRoute
                             path="/fork-time"
                             disabledFilters={[ "desk", "productionOffice" ]}
                         >
-                            <ForkTime
-                                filterVals={filterVals}
-                                isUpdating={isUpdating}
-                                charts={charts}
-                            />
+                            <ForkTimeData />
                         </TabRoute>
                         <TabRoute path="/commissioned-length">
                             <CommissionedLengthData />
@@ -93,14 +84,13 @@ const mapDispatchToProps = dispatch => ({
 });
 
 const mapStateToProps = state => {
-    const { charts, isUpdating, commissioningDesks, newspaperBooks } = state;
+    const { isUpdating, commissioningDesks, newspaperBooks } = state;
 
     const filters = getFilters(state);
 
     return {
         filterVals: filters.values,
         filterStatuses: filters.statuses,
-        charts,
         isUpdating,
         commissioningDesks,
         newspaperBooks

--- a/public/js/containers/App.js
+++ b/public/js/containers/App.js
@@ -4,8 +4,8 @@ import { bindActionCreators } from "redux";
 import actions from "actions";
 import Page from "components/Page";
 import Filters from "components/Filters/Filters";
-import { getFilters } from "../selectors";
 import OriginData from "./OriginData";
+import { getFilterVals, getFilterStatuses } from "../selectors";
 import CommissionedLengthData from "./CommissionedLengthData";
 import ForkTimeData from "./ForkTimeData";
 import ForkTime from "../components/Tabs/ForkTime";
@@ -86,11 +86,9 @@ const mapDispatchToProps = dispatch => ({
 const mapStateToProps = state => {
     const { isUpdating, commissioningDesks, newspaperBooks } = state;
 
-    const filters = getFilters(state);
-
     return {
-        filterVals: filters.values,
-        filterStatuses: filters.statuses,
+        filterVals: getFilterVals(state),
+        filterStatuses: getFilterStatuses(state),
         isUpdating,
         commissioningDesks,
         newspaperBooks

--- a/public/js/containers/App.js
+++ b/public/js/containers/App.js
@@ -6,7 +6,7 @@ import actions from "actions";
 import Page from "components/Page";
 import Filters from "components/Filters/Filters";
 import OriginData from "./OriginData";
-import { getFilterVals, getFilterStatuses } from "../selectors";
+import { getFilterVals, getFilterStatuses } from "../selectors/filters";
 import CommissionedLengthData from "./CommissionedLengthData";
 import ForkTimeData from "./ForkTimeData";
 import ForkTime from "../components/Tabs/ForkTime";

--- a/public/js/containers/App.js
+++ b/public/js/containers/App.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
+import { withRouter } from "react-router";
 import { bindActionCreators } from "redux";
 import actions from "actions";
 import Page from "components/Page";
@@ -95,4 +96,4 @@ const mapStateToProps = state => {
     };
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(App);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(App));

--- a/public/js/containers/CommissionedLengthData.js
+++ b/public/js/containers/CommissionedLengthData.js
@@ -4,7 +4,7 @@ import {
     getCommissionedLengthBands,
     getWordCountBands,
     getWordCountArticles
-} from "../selectors/index";
+} from "../selectors/commissionedLength";
 import CommissionedLength from "../components/Tabs/CommissionedLength";
 
 const mapStateToProps = state => ({

--- a/public/js/containers/ForkTimeData.js
+++ b/public/js/containers/ForkTimeData.js
@@ -1,0 +1,15 @@
+import { connect } from "react-redux";
+import { getForkTime } from "../selectors/charts";
+import { getFilterVals, getIsUpdating } from "../selectors";
+import { toggleStackChart } from "../actions";
+import ForkTime from "../components/Tabs/ForkTime";
+
+const mapStateToProps = state => ({
+    charts: {
+        forkTime: getForkTime(state)
+    },
+    filterVals: getFilterVals(state),
+    isUpdating: getIsUpdating(state)
+});
+
+export default connect(mapStateToProps)(ForkTime);

--- a/public/js/containers/ForkTimeData.js
+++ b/public/js/containers/ForkTimeData.js
@@ -1,7 +1,8 @@
 import { connect } from "react-redux";
 import { getForkTime } from "../selectors/charts";
-import { getFilterVals, getIsUpdating } from "../selectors";
 import { toggleStackChart } from "../actions";
+import { getFilterVals } from "../selectors/filters";
+import { getIsUpdating } from "../selectors/isUpdating";
 import ForkTime from "../components/Tabs/ForkTime";
 
 const mapStateToProps = state => ({

--- a/public/js/containers/OriginData.js
+++ b/public/js/containers/OriginData.js
@@ -1,0 +1,24 @@
+import { connect } from "react-redux";
+import {
+    getComposerVsIncopy,
+    getInWorkflowVsNotInWorkflow
+    
+} from "../selectors/charts";
+import { getFilterVals, getIsUpdating } from "../selectors";
+import { toggleStackChart } from "../actions";
+import Origin from "../components/Tabs/Origin";
+
+const mapStateToProps = state => ({
+    charts: {
+        composerVsInCopy: getComposerVsIncopy(state),
+        inWorkflowVsNotInWorkflow: getInWorkflowVsNotInWorkflow(state)
+    },
+    filterVals: getFilterVals(state),
+    isUpdating: getIsUpdating(state)
+});
+
+const mapDispatchToProps = dispatch => ({
+    toggleStackChart: (...args) => dispatch(toggleStackChart(...args))
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(Origin);

--- a/public/js/containers/OriginData.js
+++ b/public/js/containers/OriginData.js
@@ -4,7 +4,8 @@ import {
     getInWorkflowVsNotInWorkflow
     
 } from "../selectors/charts";
-import { getFilterVals, getIsUpdating } from "../selectors";
+import { getFilterVals } from "../selectors/filters";
+import { getIsUpdating } from "../selectors/isUpdating";
 import { toggleStackChart } from "../actions";
 import Origin from "../components/Tabs/Origin";
 

--- a/public/js/helpers/chartsHelpers.js
+++ b/public/js/helpers/chartsHelpers.js
@@ -98,11 +98,13 @@ const downloadCSV = (data, chartType, filterVals) => {
     }
 };
 
-const tidyData = (data, startDate, endDate) => {
+const fillAndSortTimeSeries = (data, startDate, endDate) => {
     const range = endDate.diff(startDate, "days");
-    return data.length <= range
-        ? fillMissingDates(startDate, endDate, data).sort(compareDates)
-        : data.sort(compareDates);
+    const data =
+        data.length <= range
+            ? fillMissingDates(startDate, endDate, data)
+            : data;
+    return data.sort(compareDates);
 };
 
 const getComparisonTimeSeriesFromResponses = (
@@ -113,8 +115,8 @@ const getComparisonTimeSeriesFromResponses = (
     countLabel1,
     countLabel2
 ) => {
-    const data1 = tidyData(res1.data, startDate, endDate);
-    const data2 = tidyData(res2.data, startDate, endDate);
+    const data1 = fillAndSortTimeSeries(res1.data, startDate, endDate);
+    const data2 = fillAndSortTimeSeries(res2.data, startDate, endDate);
     const series = [{ data: data1 }, { data: data2 }];
 
     const absolute = series.map(({ data }) => {

--- a/public/js/reducers/articleWordCountsReducer.js
+++ b/public/js/reducers/articleWordCountsReducer.js
@@ -1,11 +1,8 @@
 // TODO: remove this mock data
 import {
-wordCountBands,
-commissionedLengthBands,
-articleCount, // number
-withCommissionedLengthCount, // number
-withoutCommissionedLengthCount, // number
-articles
+    wordCountBands,
+    commissionedLengthBands,
+    articles
 } from "../components/Tabs/_commissionedLengthTestData";
 
 const initialState = {

--- a/public/js/reducers/chartsReducer.js
+++ b/public/js/reducers/chartsReducer.js
@@ -1,73 +1,74 @@
 const initialState = {
     composerVsInCopy: {
-        data: {
-            absolute: [],
-            percent: []
-        },
+        chartData: {},
+        startDate: null,
+        endDate: null,
+        pending: true,
         isStacked: true
     },
     inWorkflowVsNotInWorkflow: {
-        data: {
-            absolute: [],
-            percent: []
-        },
+        chartData: {},
+        startDate: null,
+        endDate: null,
+        pending: true,
         isStacked: true
     },
     forkTime: {
-        data: {
-            absolute: []
-        }
+        chartData: {},
+        startDate: null,
+        pending: true,
+        endDate: null,
     }
 };
 
+const chartError = (key, state, { error }) => ({
+    ...state,
+    [key]: {
+        ...state[key],
+        error,
+    }
+});
+
+const chartUpdate = (key, state, { startDate, endDate, chartData }) => ({
+    ...state,
+    [key]: {
+        ...state[key],
+        startDate,
+        endDate,
+        chartData,
+        pending: false
+    }
+});
+
 const charts = (state = initialState, action) => {
-    const { type, absolute, percent, error, isStacked } = action;
+    const { type, payload } = action;
     switch (type) {
-    case 'UPDATE_COMPOSER_VS_INCOPY': {
+    case 'UPDATE_COMPOSER_VS_INCOPY':
+        return chartUpdate("composerVsInCopy", state, payload);
+
+    case 'GET_COMPOSER_VS_INCOPY_FAILED':
+        return chartError("composerVsInCopy", state, payload);
+
+    case 'TOGGLE_STACK_CHART':
         return {
             ...state,
             composerVsInCopy: {
                 ...state.composerVsInCopy,
-                data: {
-                    absolute,
-                    percent
-                }
+                isStacked: payload.isStacked
             }
         };
-    }
-    case 'GET_COMPOSER_VS_INCOPY_FAILED':
-        return Object.assign({}, state, { composerVsInCopy: { ...state.composerVsInCopy, error }});
 
-    case 'TOGGLE_STACK_CHART':
-        return Object.assign({}, state, { composerVsInCopy: { ...state.composerVsInCopy, isStacked }});
+    case 'UPDATE_IN_WORKFLOW_VS_NOT_IN_WORKFLOW':
+        return chartUpdate("inWorkflowVsNotInWorkflow", state, payload);
 
-    case 'UPDATE_IN_WORKFLOW_VS_NOT_IN_WORKFLOW': {
-        return {
-            ...state,
-            inWorkflowVsNotInWorkflow: {
-                ...state.inWorkflowVsNotInWorkflow,
-                data: {
-                    absolute,
-                    percent
-                }
-            }
-        };  
-    }
     case 'GET_IN_WORKFLOW_VS_NOT_IN_WORKFLOW_FAILED':
-        return Object.assign({}, state, { inWorkflowVsNotInWorkflow: { ...state.inWorkflowVsNotInWorkflow, error }});
+        return chartError("inWorkflowVsNotInWorkflow", state, payload);
         
-    case 'UPDATE_FORK_TIME': {
-        return {
-            ...state,
-            forkTime: {
-                data: {
-                    absolute
-                }
-            }
-        };
-    }
-    case 'GET_FORK_TIME_FAILED': 
-        return Object.assign({}, state, { forkTime: { ...state.forkTime, error }});
+    case 'UPDATE_FORK_TIME':
+        return chartUpdate("forkTime", state, payload);
+
+    case 'GET_FORK_TIME_FAILED':
+        return chartError("forkTime", state, payload);
 
     default:
         return state;

--- a/public/js/reducers/filtersReducer.js
+++ b/public/js/reducers/filtersReducer.js
@@ -19,6 +19,7 @@ const activateAll = filters =>
 const initialState = {
     values,
     statuses: activateAll(Object.keys(values)),
+    loaded: false
 };
 
 const filterVals = (state = initialState, action) => {
@@ -26,6 +27,7 @@ const filterVals = (state = initialState, action) => {
     case 'UPDATE_FILTER':
         return {
             ...state,
+            loaded: true,
             values: {
                 ...state.values,
                 ...action.values

--- a/public/js/selectors/charts.js
+++ b/public/js/selectors/charts.js
@@ -1,126 +1,106 @@
 import moment from "moment";
 import {
-    createYTotalsList,
-    createPartialsList,
-    formattedSeries,
-    compareDates,
     compareIssueDates,
-    fillMissingDates
+    getComparisonTimeSeriesFromResponses
 } from "../helpers/chartsHelpers";
+import { createSelector } from "reselect";
 
 const getCharts = ({ charts }) => charts;
+
 const getMoments = ({ startDate, endDate }) => ({
     startDate: moment(startDate),
     endDate: moment(endDate)
 });
 
-const createComposerVsIncopyData = chart => {
-    const {
-        chartData: { composerResponse, inCopyResponse },
-        pending
-    } = chart;
+/* Composer vs Incopy */
 
-    if (pending) {
-        return {
-            absolute: [],
-            percent: []
-        };
+const getRawComposerVsIncopy = createSelector(
+    getCharts,
+    ({ composerVsInCopy }) => composerVsInCopy
+);
+
+const getComposerVsIncopyData = createSelector(
+    getRawComposerVsIncopy,
+    composerVsInCopy => {
+        const {
+            chartData: { composerResponse, inCopyResponse },
+            pending
+        } = composerVsInCopy;
+
+        if (pending) {
+            return {
+                absolute: [],
+                percent: []
+            };
+        }
+
+        const { startDate, endDate } = getMoments(composerVsInCopy);
+
+        return getComparisonTimeSeriesFromResponses(
+            composerResponse,
+            inCopyResponse,
+            startDate,
+            endDate,
+            "Created in composer",
+            "Created in InCopy"
+        );
     }
+);
 
-    const { startDate, endDate } = getMoments(chart);
-
-    const range = endDate.diff(startDate, 'days');
-    const composerData = composerResponse.data.length <= range ?  fillMissingDates(startDate, endDate, composerResponse.data).sort(compareDates) : composerResponse.data.sort(compareDates);
-    const inCopyData = inCopyResponse.data.length <= range ?  fillMissingDates(startDate, endDate, inCopyResponse.data).sort(compareDates) : inCopyResponse.data.sort(compareDates);
-    const composerVsInCopyData = [{ data: composerData }, { data: inCopyData }];
-
-    const seriesWithLabels = composerVsInCopyData.map(series => {
-        return {
-            data: series.data.map((dataPoint, index) => {
-                const date = moment(dataPoint['date']).utc();
-                return {
-                    x: date.valueOf(),
-                    y: dataPoint['count'],
-                    label: `Date: ${date.format('ddd, Do MMMM YYYY')}\nCreated in Composer: ${composerVsInCopyData[0]['data'][index]['count']}\nCreated in InCopy: ${composerVsInCopyData[1]['data'][index]['count']}`
-                };
-            })
-        };
-    });
-    const totals = createYTotalsList(createPartialsList(seriesWithLabels));
-    const percentSeries = formattedSeries(seriesWithLabels, totals);
-
-    return {
-        absolute: seriesWithLabels,
-        percent: percentSeries
-    };
-};
-
-// memoize me
-export const getComposerVsIncopy = state => {
-    const { composerVsInCopy } = getCharts(state);
-    const {
+export const getComposerVsIncopy = createSelector(
+    getRawComposerVsIncopy,
+    getComposerVsIncopyData,
+    ({ error, isStacked }, data) => ({
+        data,
         error,
         isStacked
-    } = composerVsInCopy;
+    })
+);
 
-    return {
-        data: createComposerVsIncopyData(composerVsInCopy),
-        error,
-        isStacked
-    };
-};
+/* In Workflow vs not in Workflow */
 
-const createInWorkflowVsNotInWorkflowData = chart => {
-    const {
-        chartData: { inWorkflowResponse, notInWorkflowResponse },
-        pending,
-    } = chart;
+const getRawInWorkflowVsNotInWorkflow = createSelector(
+    getCharts,
+    ({ inWorkflowVsNotInWorkflow }) => inWorkflowVsNotInWorkflow
+);
 
-    if (pending) {
-        return {
-            absolute: [],
-            percent: []
-        };
+const getInWorkflowVsNotInWorkflowData = createSelector(
+    getRawInWorkflowVsNotInWorkflow,
+    inWorkflowVsNotInWorkflow => {
+        const {
+            chartData: { inWorkflowResponse, notInWorkflowResponse },
+            pending,
+        } = inWorkflowVsNotInWorkflow;
+    
+        if (pending) {
+            return {
+                absolute: [],
+                percent: []
+            };
+        }
+
+        const { startDate, endDate } = getMoments(inWorkflowVsNotInWorkflow);
+    
+        return getComparisonTimeSeriesFromResponses(
+            inWorkflowResponse,
+            notInWorkflowResponse,
+            startDate,
+            endDate,
+            "In Workflow",
+            "Never in Workflow"
+        );
     }
+);
 
-    const { startDate, endDate } = getMoments(chart);
-
-    const range = endDate.diff(startDate, 'days');
-    const inWorkflowData = inWorkflowResponse.data.length <= range ?  fillMissingDates(startDate, endDate, inWorkflowResponse.data).sort(compareDates) : inWorkflowResponse.data.sort(compareDates);
-    const notInWorkflowData = notInWorkflowResponse.data.length <= range ?  fillMissingDates(startDate, endDate, notInWorkflowResponse.data).sort(compareDates) : notInWorkflowResponse.data.sort(compareDates);
-    const workflowVsNotInWorkflowData = [{ data: inWorkflowData }, { data: notInWorkflowData }];
-
-    const seriesWithLabels = workflowVsNotInWorkflowData.map(series => {
-        return {
-            data: series.data.map((dataPoint, index) => {
-                const date = moment(dataPoint['date']).utc();
-                return {
-                    x: date.valueOf(),
-                    y: dataPoint['count'],
-                    label: `Date: ${date.format('ddd, Do MMMM YYYY')}\nIn Workflow: ${workflowVsNotInWorkflowData[0]['data'][index]['count']}\nNever in Workflow: ${workflowVsNotInWorkflowData[1]['data'][index]['count']}`
-                };
-            })
-        };
-    });
-    const totals = createYTotalsList(createPartialsList(seriesWithLabels));
-    const percentSeries = formattedSeries(seriesWithLabels, totals);
-
-    return {
-        absolute: seriesWithLabels,
-        percent: percentSeries
-    };
-};
-
-export const getInWorkflowVsNotInWorkflow = state => {
-    const { inWorkflowVsNotInWorkflow } = getCharts(state);
-    const { error, isStacked } = inWorkflowVsNotInWorkflow;
-
-    return {
-        data: createInWorkflowVsNotInWorkflowData(inWorkflowVsNotInWorkflow),
+export const getInWorkflowVsNotInWorkflow = createSelector(
+    getRawInWorkflowVsNotInWorkflow,
+    getInWorkflowVsNotInWorkflowData,
+    ({ error, isStacked }, data) => ({
+        data,
         error,
         isStacked
-    };
-};
+    })
+);
 
 const createForkTimeData = chart => {
     const { chartData, pending } = chart;
@@ -134,7 +114,6 @@ const createForkTimeData = chart => {
 
     const forkTimeData = chartData.data.sort(compareIssueDates);
     const forkTimeSeries = [{ data: forkTimeData }];
-    console.log(forkTimeSeries);
     return {
         absolute: forkTimeSeries.map(series => ({
             data: series.data.map((dataPoint) => {

--- a/public/js/selectors/charts.js
+++ b/public/js/selectors/charts.js
@@ -41,7 +41,7 @@ const getComposerVsIncopyData = createSelector(
             inCopyResponse,
             startDate,
             endDate,
-            "Created in composer",
+            "Created in Composer",
             "Created in InCopy"
         );
     }
@@ -101,6 +101,8 @@ export const getInWorkflowVsNotInWorkflow = createSelector(
         isStacked
     })
 );
+
+/* Fork Time */
 
 const createForkTimeData = chart => {
     const { chartData, pending } = chart;

--- a/public/js/selectors/charts.js
+++ b/public/js/selectors/charts.js
@@ -1,0 +1,163 @@
+import moment from "moment";
+import {
+    createYTotalsList,
+    createPartialsList,
+    formattedSeries,
+    compareDates,
+    compareIssueDates,
+    fillMissingDates
+} from "../helpers/chartsHelpers";
+
+const getCharts = ({ charts }) => charts;
+const getMoments = ({ startDate, endDate }) => ({
+    startDate: moment(startDate),
+    endDate: moment(endDate)
+});
+
+const createComposerVsIncopyData = chart => {
+    const {
+        chartData: { composerResponse, inCopyResponse },
+        pending
+    } = chart;
+
+    if (pending) {
+        return {
+            absolute: [],
+            percent: []
+        };
+    }
+
+    const { startDate, endDate } = getMoments(chart);
+
+    const range = endDate.diff(startDate, 'days');
+    const composerData = composerResponse.data.length <= range ?  fillMissingDates(startDate, endDate, composerResponse.data).sort(compareDates) : composerResponse.data.sort(compareDates);
+    const inCopyData = inCopyResponse.data.length <= range ?  fillMissingDates(startDate, endDate, inCopyResponse.data).sort(compareDates) : inCopyResponse.data.sort(compareDates);
+    const composerVsInCopyData = [{ data: composerData }, { data: inCopyData }];
+
+    const seriesWithLabels = composerVsInCopyData.map(series => {
+        return {
+            data: series.data.map((dataPoint, index) => {
+                const date = moment(dataPoint['date']).utc();
+                return {
+                    x: date.valueOf(),
+                    y: dataPoint['count'],
+                    label: `Date: ${date.format('ddd, Do MMMM YYYY')}\nCreated in Composer: ${composerVsInCopyData[0]['data'][index]['count']}\nCreated in InCopy: ${composerVsInCopyData[1]['data'][index]['count']}`
+                };
+            })
+        };
+    });
+    const totals = createYTotalsList(createPartialsList(seriesWithLabels));
+    const percentSeries = formattedSeries(seriesWithLabels, totals);
+
+    return {
+        absolute: seriesWithLabels,
+        percent: percentSeries
+    };
+};
+
+// memoize me
+export const getComposerVsIncopy = state => {
+    const { composerVsInCopy } = getCharts(state);
+    const {
+        error,
+        isStacked
+    } = composerVsInCopy;
+
+    return {
+        data: createComposerVsIncopyData(composerVsInCopy),
+        error,
+        isStacked
+    };
+};
+
+const createInWorkflowVsNotInWorkflowData = chart => {
+    const {
+        chartData: { inWorkflowResponse, notInWorkflowResponse },
+        pending,
+    } = chart;
+
+    if (pending) {
+        return {
+            absolute: [],
+            percent: []
+        };
+    }
+
+    const { startDate, endDate } = getMoments(chart);
+
+    const range = endDate.diff(startDate, 'days');
+    const inWorkflowData = inWorkflowResponse.data.length <= range ?  fillMissingDates(startDate, endDate, inWorkflowResponse.data).sort(compareDates) : inWorkflowResponse.data.sort(compareDates);
+    const notInWorkflowData = notInWorkflowResponse.data.length <= range ?  fillMissingDates(startDate, endDate, notInWorkflowResponse.data).sort(compareDates) : notInWorkflowResponse.data.sort(compareDates);
+    const workflowVsNotInWorkflowData = [{ data: inWorkflowData }, { data: notInWorkflowData }];
+
+    const seriesWithLabels = workflowVsNotInWorkflowData.map(series => {
+        return {
+            data: series.data.map((dataPoint, index) => {
+                const date = moment(dataPoint['date']).utc();
+                return {
+                    x: date.valueOf(),
+                    y: dataPoint['count'],
+                    label: `Date: ${date.format('ddd, Do MMMM YYYY')}\nIn Workflow: ${workflowVsNotInWorkflowData[0]['data'][index]['count']}\nNever in Workflow: ${workflowVsNotInWorkflowData[1]['data'][index]['count']}`
+                };
+            })
+        };
+    });
+    const totals = createYTotalsList(createPartialsList(seriesWithLabels));
+    const percentSeries = formattedSeries(seriesWithLabels, totals);
+
+    return {
+        absolute: seriesWithLabels,
+        percent: percentSeries
+    };
+};
+
+export const getInWorkflowVsNotInWorkflow = state => {
+    const { inWorkflowVsNotInWorkflow } = getCharts(state);
+    const { error, isStacked } = inWorkflowVsNotInWorkflow;
+
+    return {
+        data: createInWorkflowVsNotInWorkflowData(inWorkflowVsNotInWorkflow),
+        error,
+        isStacked
+    };
+};
+
+const createForkTimeData = chart => {
+    const { chartData, pending } = chart;
+    if (pending) {
+        return {
+            absolute: []
+        };
+    }
+
+    const { startDate, endDate } = getMoments(chart);
+
+    const forkTimeData = chartData.data.sort(compareIssueDates);
+    const forkTimeSeries = [{ data: forkTimeData }];
+    console.log(forkTimeSeries);
+    return {
+        absolute: forkTimeSeries.map(series => ({
+            data: series.data.map((dataPoint) => {
+                const date = moment(dataPoint['issueDate']).utc();
+                const hours = dataPoint.timeToPublication / 3600 / 1000;
+                return {
+                    x: date,
+                    y: hours,
+                    label: `${hours.toFixed(1)} hours`,
+                    size: 2.5
+                };
+            })
+        }))
+    };
+};
+
+export const getForkTime = state => {
+    const { forkTime } = getCharts(state);
+    const { isStacked, error } = forkTime;
+
+    return {
+        data: createForkTimeData(forkTime),
+        error,
+        isStacked
+    };
+};

--- a/public/js/selectors/commissionedLength.js
+++ b/public/js/selectors/commissionedLength.js
@@ -1,24 +1,4 @@
-import moment from "moment";
 import { createSelector } from "reselect";
-
-export const getIsUpdating = ({ isUpdating }) => isUpdating;
-
-/* Filters */
-
-const getFilters = ({ filters }) => filters;
-
-export const getFilterVals = createSelector(getFilters, ({ values }) => ({
-    ...values,
-    startDate: moment(values.startDate),
-    endDate: moment(values.endDate)
-}));
-
-export const getFilterStatuses = createSelector(
-    getFilters,
-    ({ statuses }) => statuses
-);
-
-/* Commissioned length */
 
 const getArticleWordCounts = ({ articleWordCounts }) => articleWordCounts;
 

--- a/public/js/selectors/filters.js
+++ b/public/js/selectors/filters.js
@@ -1,0 +1,15 @@
+import moment from "moment";
+import { createSelector } from "reselect";
+
+const getFilters = ({ filters }) => filters;
+
+export const getFilterVals = createSelector(getFilters, ({ values }) => ({
+    ...values,
+    startDate: moment(values.startDate),
+    endDate: moment(values.endDate)
+}));
+
+export const getFilterStatuses = createSelector(
+    getFilters,
+    ({ statuses }) => statuses
+);

--- a/public/js/selectors/index.js
+++ b/public/js/selectors/index.js
@@ -11,6 +11,10 @@ export const getFilters = memoize(({ filters }) => ({
     }
 }));
 
+export const getIsUpdating = ({ isUpdating }) => isUpdating;
+
+export const getFilterVals = state => getFilters(state).values;
+
 const getArticleWordCounts = ({ articleWordCounts }) => articleWordCounts;
 
 export const getWordCountArticles = state =>

--- a/public/js/selectors/index.js
+++ b/public/js/selectors/index.js
@@ -1,39 +1,62 @@
 import moment from "moment";
-import memoize from "lodash/memoize";
-
-// If the state object is the same then just return the same obj
-export const getFilters = memoize(({ filters }) => ({
-    ...filters,
-    values: {
-        ...filters.values,
-        startDate: moment(filters.values.startDate),
-        endDate: moment(filters.values.endDate)
-    }
-}));
+import { createSelector } from "reselect";
 
 export const getIsUpdating = ({ isUpdating }) => isUpdating;
 
-export const getFilterVals = state => getFilters(state).values;
+/* Filters */
+
+const getFilters = ({ filters }) => filters;
+
+export const getFilterVals = createSelector(getFilters, ({ values }) => ({
+    ...values,
+    startDate: moment(values.startDate),
+    endDate: moment(values.endDate)
+}));
+
+export const getFilterStatuses = createSelector(
+    getFilters,
+    ({ statuses }) => statuses
+);
+
+/* Commissioned length */
 
 const getArticleWordCounts = ({ articleWordCounts }) => articleWordCounts;
 
-export const getWordCountArticles = state =>
-    getArticleWordCounts(state).articles;
+export const getWordCountArticles = createSelector(
+    getArticleWordCounts,
+    ({ articles }) => articles
+);
 
-export const getWordCountAggregates = state =>
-    getArticleWordCounts(state).aggregates;
+export const getWordCountAggregates = createSelector(
+    getArticleWordCounts,
+    ({ aggregates }) => aggregates
+);
 
-export const getWordCountBands = state =>
-    getWordCountAggregates(state).wordCountBands;
+export const getWordCountBands = createSelector(
+    getWordCountAggregates,
+    ({ wordCountBands }) => wordCountBands
+);
 
-export const getCommissionedLengthBands = state =>
-    getWordCountAggregates(state).commissionedLengthBands;
+export const getCommissionedLengthBands = createSelector(
+    getWordCountAggregates,
+    ({ commissionedLengthBands }) => commissionedLengthBands
+);
 
 const sumCounts = arr => arr.reduce((sum, { count }) => sum + count, 0);
 
-export const getArticleCount = state => sumCounts(getWordCountBands(state));
-export const withCommissionedLengthCount = state =>
-    sumCounts(getCommissionedLengthBands(state));
+export const getArticleCount = createSelector(
+    getWordCountBands,
+    wordCountBands => sumCounts(wordCountBands)
+);
 
-export const getWithoutCommissionedLengthCount = state =>
-    getArticleCount(state) - withCommissionedLengthCount(state);
+export const getWithCommissionedLengthCount = createSelector(
+    getCommissionedLengthBands,
+    commissionedLengthBands => sumCounts(commissionedLengthBands)
+);
+
+export const getWithoutCommissionedLengthCount = createSelector(
+    getArticleCount,
+    getWithCommissionedLengthCount,
+    (articleCount, commissionedLengthCount) =>
+        articleCount - commissionedLengthCount
+);

--- a/public/js/selectors/isUpdating.js
+++ b/public/js/selectors/isUpdating.js
@@ -1,0 +1,7 @@
+/*
+TODO: to keep the structure of selectors consistent (files for reducers) this
+func is in a single file, which seems overkill! In future we could bundle flags
+into one reducer and keep all of them here.
+*/
+
+export const getIsUpdating = ({ isUpdating }) => isUpdating;

--- a/public/js/services/routingMiddleware.js
+++ b/public/js/services/routingMiddleware.js
@@ -29,10 +29,10 @@ export const updateUrlFromStateChangeMiddleware = ({ dispatch, getState }) => (n
 };
 
 export const updateStateFromUrlChangeMiddleware = ({ dispatch, getState }) => (next) => (action) => {
-    next(action);
+    const results = next(action);
     const newState = getState();
 
-    if (action.type === '@@router/LOCATION_CHANGE' && !newState.filtersloaded) {
+    if (action.type === '@@router/LOCATION_CHANGE') {
         const filterObj = paramStringToObject(newState.routing.location.search);
 
         const nextFilterVals = {
@@ -40,6 +40,10 @@ export const updateStateFromUrlChangeMiddleware = ({ dispatch, getState }) => (n
             ...filterObj
         };
 
-        dispatch(runFilter(nextFilterVals));
+        if (!_isEqual(newState.filters.values, nextFilterVals) || !newState.filters.loaded) {
+            dispatch(runFilter(nextFilterVals));
+        }
     }
+
+    return results;
 };

--- a/public/js/services/routingMiddleware.js
+++ b/public/js/services/routingMiddleware.js
@@ -32,7 +32,7 @@ export const updateStateFromUrlChangeMiddleware = ({ dispatch, getState }) => (n
     next(action);
     const newState = getState();
 
-    if (action.type === '@@router/LOCATION_CHANGE') {
+    if (action.type === '@@router/LOCATION_CHANGE' && !newState.filtersloaded) {
         const filterObj = paramStringToObject(newState.routing.location.search);
 
         const nextFilterVals = {
@@ -40,11 +40,6 @@ export const updateStateFromUrlChangeMiddleware = ({ dispatch, getState }) => (n
             ...filterObj
         };
 
-        // In practice this stops react-router running the filters unless it's a
-        // page load as these should never not be equal during this action
-        // TODO: get the router info through other means on page load
-        if (!_isEqual(nextFilterVals, newState.filters.values)) {
-            dispatch(runFilter(nextFilterVals));
-        }
+        dispatch(runFilter(nextFilterVals));
     }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3630,6 +3630,10 @@ require-uncached@^1.0.3:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
+reselect@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
+
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"


### PR DESCRIPTION
This memoize all of the derived data and takes the creation of this data out of the action and into a memoized function that gets called at render time. This means we can keep the raw data in the reducer and maybe show this data in different ways in different places if required. It also will allow us to test our actions without testing the logic of the chart data creation.

This uses the [reselect](https://github.com/reactjs/reselect) library

Additionally there were some bugs with routing that are now fixed, mainly that the only thing forcing a rerender of any new routes was the `dispatch` call in some middleware, as the `App` hadn't been connected to the router.

`App` also has some connected components beneath it now so it doesn't have to pass down the store state as props. This could also be done with the filters state to trim down the `App` component even more.

Happy to talk through this with people so it's easier for you to spot any mistakes I've made!