### PR TITLE
Fix blank newspaper book

### DIFF
--- a/app/database/MetricsDB.scala
+++ b/app/database/MetricsDB.scala
@@ -56,5 +56,5 @@ class MetricsDB(implicit val db: Database) {
       }
 
   def getDistinctNewspaperBooks: Either[ProductionMetricsError, Seq[Option[String]]] =
-    await(db.run(metricsTable.filter(book => !book.newspaperBook.isEmpty && book.newspaperBook.eq(Some(""))).map(_.newspaperBook).distinct.result))
+    await(db.run(metricsTable.filter(book => !book.newspaperBook.isEmpty && book.newspaperBook =!= "").map(_.newspaperBook).distinct.result))
 }

--- a/app/database/MetricsDB.scala
+++ b/app/database/MetricsDB.scala
@@ -56,5 +56,5 @@ class MetricsDB(implicit val db: Database) {
       }
 
   def getDistinctNewspaperBooks: Either[ProductionMetricsError, Seq[Option[String]]] =
-    await(db.run(metricsTable.filter(!_.newspaperBook.isEmpty).map(_.newspaperBook).distinct.result))
+    await(db.run(metricsTable.filter(book => !book.newspaperBook.isEmpty && book.newspaperBook.eq(Some(""))).map(_.newspaperBook).distinct.result))
 }


### PR DESCRIPTION
Some newspaper books are sent through from incopy as empty strings. Filter these out when creating a list of newspaper books