### PR TITLE
Update how filtering works on the DB

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -95,8 +95,8 @@ class Application(implicit val wsClient: WSClient, val db: MetricsDB) extends Co
   def getArticlesWithWordCounts() = APIAuthAction { req =>
     APIResponse {
       for {
-        articlesWithoutCommissionedLength <- db.getArticlesWithWordCounts(withCommissionedLength=false)(Filters(req.queryString))
-        articlesWithCommissionedLength <- db.getArticlesWithWordCounts(withCommissionedLength=true)(Filters(req.queryString))
+        articlesWithoutCommissionedLength <- db.getArticlesWithWordCounts(Filters(req.queryString).copy(hasCommissionedLength = Some(false)))
+        articlesWithCommissionedLength <- db.getArticlesWithWordCounts(Filters(req.queryString).copy(hasCommissionedLength = Some(true)))
       } yield WordCountAPIResponse(articlesWithoutCommissionedLength, articlesWithCommissionedLength)
     }
   }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -97,9 +97,7 @@ class Application(implicit val wsClient: WSClient, val db: MetricsDB) extends Co
       for {
         articlesWithoutCommissionedLength <- db.getArticlesWithWordCounts(withCommissionedLength=false)(Filters(req.queryString))
         articlesWithCommissionedLength <- db.getArticlesWithWordCounts(withCommissionedLength=true)(Filters(req.queryString))
-      } yield {
-        WordCountAPIResponse(articlesWithoutCommissionedLength, articlesWithCommissionedLength)
-      }
+      } yield WordCountAPIResponse(articlesWithoutCommissionedLength, articlesWithCommissionedLength)
     }
   }
 

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -6,7 +6,7 @@ import config.Config._
 import database.MetricsDB
 import io.circe.generic.auto._
 import models.{WordCountAPIResponse, APIResponse}
-import models.db.{Fork, MetricsFilters}
+import models.db.{Fork, Filters}
 import play.api.Logger
 import play.api.libs.ws.WSClient
 import play.api.mvc._
@@ -44,7 +44,7 @@ class Application(implicit val wsClient: WSClient, val db: MetricsDB) extends Co
     APIResponse {
       for {
         originatingSystem <- extractOriginatingSystem(system)
-        filters = MetricsFilters(req.queryString).copy(originatingSystem = Some(originatingSystem))
+        filters = Filters(req.queryString).copy(originatingSystem = Some(originatingSystem))
         metric <- db.getGroupedByDayMetrics(filters)
       } yield metric
     }
@@ -53,7 +53,7 @@ class Application(implicit val wsClient: WSClient, val db: MetricsDB) extends Co
   def getWorkflowData(inWorkflow: Boolean) = APIAuthAction { req =>
     APIResponse {
       for {
-        metric <- db.getGroupedByDayMetrics(MetricsFilters(req.queryString).copy(inWorkflow = Some(inWorkflow)))
+        metric <- db.getGroupedByDayMetrics(Filters(req.queryString).copy(inWorkflow = Some(inWorkflow)))
       } yield metric
     }
   }
@@ -86,7 +86,7 @@ class Application(implicit val wsClient: WSClient, val db: MetricsDB) extends Co
 
   def getForks(newspaperBook: String) = APIAuthAction { req =>
     APIResponse {
-      db.getForks(MetricsFilters(req.queryString).copy(newspaperBook = Some(newspaperBook)))
+      db.getForks(Filters(req.queryString).copy(newspaperBook = Some(newspaperBook)))
     }
   }
 
@@ -95,8 +95,8 @@ class Application(implicit val wsClient: WSClient, val db: MetricsDB) extends Co
   def getArticlesWithWordCounts() = APIAuthAction { req =>
     APIResponse {
       for {
-        articlesWithoutCommissionedLength <- db.getArticlesWithWordCounts(withCommissionedLength=false)(MetricsFilters(req.queryString))
-        articlesWithCommissionedLength <- db.getArticlesWithWordCounts(withCommissionedLength=true)(MetricsFilters(req.queryString))
+        articlesWithoutCommissionedLength <- db.getArticlesWithWordCounts(withCommissionedLength=false)(Filters(req.queryString))
+        articlesWithCommissionedLength <- db.getArticlesWithWordCounts(withCommissionedLength=true)(Filters(req.queryString))
       } yield {
         WordCountAPIResponse(articlesWithoutCommissionedLength, articlesWithCommissionedLength)
       }
@@ -106,7 +106,7 @@ class Application(implicit val wsClient: WSClient, val db: MetricsDB) extends Co
   def getGroupedWordCounts() = APIAuthAction { req =>
     APIResponse {
       for {
-        groupedWordCounts <- db.getGroupedWordCounts(MetricsFilters(req.queryString))
+        groupedWordCounts <- db.getGroupedWordCounts(Filters(req.queryString))
       } yield groupedWordCounts
     }
   }

--- a/app/database/MetricsDB.scala
+++ b/app/database/MetricsDB.scala
@@ -49,7 +49,7 @@ class MetricsDB(implicit val db: Database) {
   // This needs to return the data grouped by day. For this we've defined dateTrunc to tell Slick
   // to "import" the date_trunc function from postgresql
   def getGroupedByDayMetrics(implicit filters: Filters): Either[ProductionMetricsError, List[CountResponse]] =
-    awaitWithTransformation(db.run(metricsTable.filter(Filters.metricFilters).map(m => (m.id, m.creationTime.toDayDateTrunc))
+    awaitWithTransformation(db.run(metricsTable.filter(Filters.originFilters).map(m => (m.id, m.creationTime.toDayDateTrunc))
       .groupBy(_._2).map {
         case (date, metric) => (date, metric.size)
       }.result)){ dbResult: Seq[(DateTime, Int)] =>
@@ -68,7 +68,7 @@ class MetricsDB(implicit val db: Database) {
     )
 
     awaitWithTransformation(db.run(metricsTable
-      .filter(Filters.metricFilters)
+      .filter(Filters.originFilters)
       .map( metric =>
         Case
           If(metric.wordCount between(0, lowerBoundsToUpperBounds.get(0).get)) Then 0

--- a/app/database/MetricsDB.scala
+++ b/app/database/MetricsDB.scala
@@ -91,13 +91,8 @@ class MetricsDB(implicit val db: Database) {
     })
   }
 
-<<<<<<< HEAD
-  def getArticlesWithWordCounts(withCommissionedLength: Boolean)(implicit filters: MetricsFilters):
-    Either[ProductionMetricsError, ArticleWordCountResponseList] = {
-=======
   def getArticlesWithWordCounts(withCommissionedLength: Boolean)(implicit filters: Filters):
-    Either[ProductionMetricsError, List[ArticleWordCountResponse]] = {
->>>>>>> Rename MetricsFilters to Filters to reflect their more general use.
+    Either[ProductionMetricsError, ArticleWordCountResponseList] = {
 
     val filterFunction = if (withCommissionedLength)
       Filters.withCommissionedWordCountFilters

--- a/app/database/MetricsDB.scala
+++ b/app/database/MetricsDB.scala
@@ -91,14 +91,10 @@ class MetricsDB(implicit val db: Database) {
     })
   }
 
-  def getArticlesWithWordCounts(withCommissionedLength: Boolean)(implicit filters: Filters):
+  def getArticlesWithWordCounts(implicit filters: Filters):
     Either[ProductionMetricsError, ArticleWordCountResponseList] = {
 
-    val filterFunction = if (withCommissionedLength)
-      Filters.withCommissionedWordCountFilters
-    else Filters.withoutCommissionedWordCountFilters
-
-    awaitWithTransformation(db.run(metricsTable.filter(filterFunction)
+    awaitWithTransformation(db.run(metricsTable.filter(Filters.wordCountFilters)
       .sortBy((metric) => {
         for {
           wordCount <- metric.wordCount

--- a/app/models/db/Filters.scala
+++ b/app/models/db/Filters.scala
@@ -79,13 +79,13 @@ object Filters {
                                                (implicit filters: Filters): Rep[Option[Boolean]] = {
     filters.hasCommissionedLength.fold(TrueOptCol)(booleanValue => metric.commissionedWordCount.isDefined.? === booleanValue) &&
       filters.dateRange.fold(TrueOptCol)(dr => metric.firstPublicationTime >= dr.from && metric.firstPublicationTime <= dr.to) &&
-      checkCommonFilters(metric)
+      commonFilters(metric)
   }
   private def combineFiltersForFork(data: (ForkFilterColumns, Schema.DBMetric))(implicit filters: Filters): Rep[Option[Boolean]] = {
     val (fork, metric) = data
     filters.dateRange.fold(TrueOptCol)(dr => fork._3.? >= dr.from && fork._3.? <= dr.to) &&
       filters.newspaperBook.fold(TrueOptCol)(nb => metric.newspaperBook.toLowerCase === nb.toLowerCase) &&
-      checkCommonFilters(metric)
+      commonFilters(metric)
   }
 
   private def combineFiltersForOrigin(metric: Schema.DBMetric)(implicit filters: Filters): Rep[Option[Boolean]] = {
@@ -93,10 +93,10 @@ object Filters {
     filters.dateRange.fold(TrueOptCol)(dr => metric.creationTime.? >= dr.from && metric.creationTime.? <= dr.to) &&
       filters.inWorkflow.fold(TrueOptCol)(inWf => metric.inWorkflow.? === inWf) &&
       filters.originatingSystem.fold(TrueOptCol)(os => metric.originatingSystem.? === os) &&
-      checkCommonFilters(metric)
+      commonFilters(metric)
   }
 
-  private def checkCommonFilters(metric: Schema.DBMetric)(implicit filters: Filters): Rep[Option[Boolean]] = {
+  private def commonFilters(metric: Schema.DBMetric)(implicit filters: Filters): Rep[Option[Boolean]] = {
     import MetricHelpers._
     filters.desk.fold(TrueOptCol)(d => metric.commissioningDesk.toLowerCase === d.toLowerCase) &&
       filters.productionOffice.fold(TrueOptCol)(po => metric.productionOffice === po)

--- a/app/models/db/Filters.scala
+++ b/app/models/db/Filters.scala
@@ -78,7 +78,8 @@ object Filters {
   private def combineFiltersForWordCount(metric: Schema.DBMetric)
                                                (implicit filters: Filters): Rep[Option[Boolean]] = {
     filters.hasCommissionedLength.fold(TrueOptCol)(booleanValue => metric.commissionedWordCount.isDefined.? === booleanValue) &&
-      combineFiltersForOrigin(metric)
+      filters.dateRange.fold(TrueOptCol)(dr => metric.firstPublicationTime >= dr.from && metric.firstPublicationTime <= dr.to) &&
+      checkCommonFilters(metric)
   }
   private def combineFiltersForFork(data: (ForkFilterColumns, Schema.DBMetric))(implicit filters: Filters): Rep[Option[Boolean]] = {
     val (fork, metric) = data

--- a/app/models/db/MetricsFilters.scala
+++ b/app/models/db/MetricsFilters.scala
@@ -79,7 +79,7 @@ object MetricsFilters {
 
   private def checkCommissionedWordCountFilters(metric: Schema.DBMetric, withCommissionedWordCount: Boolean)
                                                (implicit filters: MetricsFilters): Rep[Option[Boolean]] = {
-    Some(withCommissionedWordCount).fold(TrueOptCol)(booleanValue => metric.commissionedWordCount.isDefined === booleanValue) &&
+    Some(withCommissionedWordCount).fold(TrueOptCol)(booleanValue => metric.commissionedWordCount.isDefined.? === booleanValue) &&
     checkMetricsFilters(metric)
   }
   private def checkMetricsForkFilters(data: (ForkFilterColumns, Schema.DBMetric))(implicit filters: MetricsFilters): Rep[Option[Boolean]] = {

--- a/test-integration/controllers/MetricsDBSpec.scala
+++ b/test-integration/controllers/MetricsDBSpec.scala
@@ -4,7 +4,7 @@ import com.gu.editorialproductionmetricsmodels.models.{MetricOpt, ProductionOffi
 import database.MetricsDB
 import helpers.{PostgresHelpers, TestData}
 import models.ProductionMetricsError
-import models.db.{ForkResponse, Metric, MetricsFilters}
+import models.db.{ForkResponse, Metric, Filters}
 import org.joda.time.DateTime
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSuite, Matchers}
@@ -60,7 +60,7 @@ class MetricsDBSpec extends FunSuite with MockitoSugar with Matchers with Result
   }
 
   test("Get forks with filter") {
-    val getInitialForks = metricsDb.getForks(MetricsFilters())
+    val getInitialForks = metricsDb.getForks(Filters())
     getInitialForks shouldBe a [Right[_,_]]
 
     TestData.addMetric(TestData.randomMetricWith("composerId_fork1", "storyBundleId_fork1").copy(commissioningDesk = Some("testFilters")))
@@ -69,7 +69,7 @@ class MetricsDBSpec extends FunSuite with MockitoSugar with Matchers with Result
     TestData.addMetric(TestData.randomMetricWith("composerId_fork2", "storyBundleId_fork2").copy(commissioningDesk = Some("testFilters")))
     TestData.addFork(TestData.randomForkWith("composerId_fork2", new DateTime("2017-11-11")).copy(timeToPublication = Some(4321)))
 
-    val getFilteredForks = metricsDb.getForks(MetricsFilters(desk = Some("testFilters")))
+    val getFilteredForks = metricsDb.getForks(Filters(desk = Some("testFilters")))
     getFilteredForks shouldBe a [Right[_,_]]
 
     val filteredResult = getFilteredForks.right.get

--- a/test/FiltersSpec.scala
+++ b/test/FiltersSpec.scala
@@ -1,13 +1,13 @@
 import com.gu.editorialproductionmetricsmodels.models.{OriginatingSystem, ProductionOffice}
-import models.db.{DateRange, MetricsFilters}
+import models.db.{DateRange, Filters}
 import org.joda.time.DateTime
 
-class MetricsFiltersSpec extends BaseSuite {
+class FiltersSpec extends BaseSuite {
   test("create a MetricFilter from a valid query string") {
     val queryString = Map("productionOffice" -> Seq("uk"), "desk" -> Seq("news"), "originatingSystem" -> Seq("composer"))
-    val metricsFilters = MetricsFilters(queryString)
+    val metricsFilters = Filters(queryString)
     metricsFilters should equal(
-      MetricsFilters(
+      Filters(
         productionOffice = Some(ProductionOffice.Uk),
         desk = Some("news"),
         originatingSystem = Some(OriginatingSystem.Composer)
@@ -16,27 +16,27 @@ class MetricsFiltersSpec extends BaseSuite {
 
   test("create a MetricFilter with correct date range from startDate and endDate parameters") {
     val queryString = Map("startDate" -> Seq("2017-08-01T00:00:00Z"), "endDate" -> Seq("2017-08-31T00:00:00Z"))
-    val metricsFilters = MetricsFilters(queryString)
+    val metricsFilters = Filters(queryString)
     metricsFilters should equal(
-      MetricsFilters(
+      Filters(
         dateRange = Some(DateRange(from = new DateTime("2017-08-01T00:00:00Z"), to = new DateTime("2017-08-31T00:00:00Z")))
       ))
   }
 
   test("create a MetricFilter with correct date range from date = today") {
     val queryString = Map("date" -> Seq("today"))
-    val metricsFilters = MetricsFilters(queryString)
+    val metricsFilters = Filters(queryString)
     metricsFilters should equal(
-      MetricsFilters(
+      Filters(
         dateRange = Some(DateRange(from = DateTime.now().withTimeAtStartOfDay(), to = metricsFilters.dateRange.get.to))
       ))
   }
 
   test("create a MetricFilter with correct date range from date = yesterday") {
     val queryString = Map("date" -> Seq("yesterday"))
-    val metricsFilters = MetricsFilters(queryString)
+    val metricsFilters = Filters(queryString)
     metricsFilters should equal(
-      MetricsFilters(
+      Filters(
         dateRange = Some(DateRange(from = DateTime.now().minusDays(1).withTimeAtStartOfDay(), to = DateTime.now().withTimeAtStartOfDay()))
       ))
   }


### PR DESCRIPTION
1. Refactored the database filters to improve the naming and how we filter to make it more consistent.

2. Updated word counts filter to filter on published date as opposed to creation date as this seems more sensible as it shows what was finished on a given day as then we will know if the piece was under the word count. Going to confirm this with Chris Moran