### PR TITLE
Add grouped commissioning endpoint

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -104,7 +104,7 @@ class Application(implicit val wsClient: WSClient, val db: MetricsDB) extends Co
   def getGroupedArticleLengths() = APIAuthAction { req =>
     APIResponse {
       for {
-        groupedArticleLengths <- db.getGroupedArticleLengths(Filters(req.queryString))
+        groupedArticleLengths <- db.getArticlesGroupedByLengthBounds()(Filters(req.queryString))
       } yield groupedArticleLengths
     }
   }
@@ -112,7 +112,7 @@ class Application(implicit val wsClient: WSClient, val db: MetricsDB) extends Co
   def getGroupedCommissionedLengths() = APIAuthAction { req =>
     APIResponse {
       for {
-        groupedCommissionedLengths <- db.getGroupedCommissionedLengths(Filters(req.queryString))
+        groupedCommissionedLengths <- db.getArticlesGroupedByLengthBounds(groupByCommissionedLength = true)(Filters(req.queryString))
       } yield groupedCommissionedLengths
     }
   }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -101,19 +101,19 @@ class Application(implicit val wsClient: WSClient, val db: MetricsDB) extends Co
     }
   }
 
-  def getGroupedArticleLengths() = APIAuthAction { req =>
+  def getArticlesGroupedByLength() = APIAuthAction { req =>
     APIResponse {
       for {
-        groupedArticleLengths <- db.getArticlesGroupedByLengthBounds()(Filters(req.queryString))
-      } yield groupedArticleLengths
+        groupedByArticleLength <- db.getArticlesGroupedByLengthBounds()(Filters(req.queryString))
+      } yield groupedByArticleLength
     }
   }
 
-  def getGroupedCommissionedLengths() = APIAuthAction { req =>
+  def getArticlesGroupedByCommissionedLength() = APIAuthAction { req =>
     APIResponse {
       for {
-        groupedCommissionedLengths <- db.getArticlesGroupedByLengthBounds(groupByCommissionedLength = true)(Filters(req.queryString))
-      } yield groupedCommissionedLengths
+        groupedByCommissionedLength <- db.getArticlesGroupedByLengthBounds(groupByCommissionedLength = true)(Filters(req.queryString))
+      } yield groupedByCommissionedLength
     }
   }
 }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -101,11 +101,19 @@ class Application(implicit val wsClient: WSClient, val db: MetricsDB) extends Co
     }
   }
 
-  def getGroupedWordCounts() = APIAuthAction { req =>
+  def getGroupedArticleLengths() = APIAuthAction { req =>
     APIResponse {
       for {
-        groupedWordCounts <- db.getGroupedWordCounts(Filters(req.queryString))
-      } yield groupedWordCounts
+        groupedArticleLengths <- db.getGroupedArticleLengths(Filters(req.queryString))
+      } yield groupedArticleLengths
+    }
+  }
+
+  def getGroupedCommissionedLengths() = APIAuthAction { req =>
+    APIResponse {
+      for {
+        groupedCommissionedLengths <- db.getGroupedCommissionedLengths(Filters(req.queryString))
+      } yield groupedCommissionedLengths
     }
   }
 }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -5,8 +5,8 @@ import com.gu.editorialproductionmetricsmodels.models.{ForkData, MetricOpt}
 import config.Config._
 import database.MetricsDB
 import io.circe.generic.auto._
-import models.{WordCountAPIResponse, APIResponse}
-import models.db.{Fork, Filters}
+import models.{APIResponse, WordCountAPIResponse}
+import models.db.{CommissionedLength, Filters, FinalLength, Fork}
 import play.api.Logger
 import play.api.libs.ws.WSClient
 import play.api.mvc._
@@ -101,18 +101,18 @@ class Application(implicit val wsClient: WSClient, val db: MetricsDB) extends Co
     }
   }
 
-  def getArticlesGroupedByLength() = APIAuthAction { req =>
+  def getArticlesGroupedByFinalLength() = APIAuthAction { req =>
     APIResponse {
       for {
-        groupedByArticleLength <- db.getArticlesGroupedByLengthBounds()(Filters(req.queryString))
-      } yield groupedByArticleLength
+        groupedByFinalLength <- db.getArticlesGroupedByLengthBounds(FinalLength)(Filters(req.queryString))
+      } yield groupedByFinalLength
     }
   }
 
   def getArticlesGroupedByCommissionedLength() = APIAuthAction { req =>
     APIResponse {
       for {
-        groupedByCommissionedLength <- db.getArticlesGroupedByLengthBounds(groupByCommissionedLength = true)(Filters(req.queryString))
+        groupedByCommissionedLength <- db.getArticlesGroupedByLengthBounds(CommissionedLength)(Filters(req.queryString))
       } yield groupedByCommissionedLength
     }
   }

--- a/app/database/MetricsDB.scala
+++ b/app/database/MetricsDB.scala
@@ -59,7 +59,7 @@ class MetricsDB(implicit val db: Database) {
   def getDistinctNewspaperBooks: Either[ProductionMetricsError, Seq[Option[String]]] =
     await(db.run(metricsTable.filter(book => !book.newspaperBook.isEmpty && book.newspaperBook =!= "").map(_.newspaperBook).distinct.result))
 
-  def getGroupedArticleLengths(implicit filters: Filters): Either[ProductionMetricsError, List[ArticleLengthGroup]] = {
+  def getArticlesGroupedByLengthBounds(groupByCommissionedLength: Boolean = false)(implicit filters: Filters): Either[ProductionMetricsError, List[ArticleLengthGroup]] = {
 
     val lowerBoundsToUpperBounds: Map[Int, Int] = Map(
       0 -> 349,
@@ -67,47 +67,16 @@ class MetricsDB(implicit val db: Database) {
       650 -> 899
     )
 
-    awaitWithTransformation(db.run(metricsTable
-      .filter(Filters.originFilters)
-      .map( metric =>
-        Case
-          If(metric.wordCount between(0, lowerBoundsToUpperBounds.get(0).get)) Then 0
-          If(metric.wordCount between(350, lowerBoundsToUpperBounds.get(350).get)) Then 350
-          If(metric.wordCount between(650, lowerBoundsToUpperBounds.get(650).get)) Then 650
-          If(metric.wordCount >= 900) Then 900
-      )
-      .groupBy(identity)
-      .map{case (lowerBound, metric) => (lowerBound, metric.size)}
-      .result))(dbResult => {
-
-      dbResult.foldRight(List[ArticleLengthGroup]())((result: (Option[Int], Int), wordCounts: List[ArticleLengthGroup]) => {
-        result match {
-          case (None, _) => wordCounts
-          case (Some(lowerBound), count) => {
-            wordCounts ::: List(ArticleLengthGroup((lowerBound, lowerBoundsToUpperBounds.get(lowerBound)), count))
-          }
-        }
-      }).sortWith(_.range._1 < _.range._1)
-    })
-  }
-
-  def getGroupedCommissionedLengths(implicit filters: Filters): Either[ProductionMetricsError, List[ArticleLengthGroup]] = {
-
-    val lowerBoundsToUpperBounds: Map[Int, Int] = Map(
-      0 -> 349,
-      350 -> 649,
-      650 -> 899
-    )
+    def assignLowerBound(length: Rep[Option[Int]]): Case.TypedCase[Int, Int] =
+      (Case
+        If(length between(0, lowerBoundsToUpperBounds.get(0).get)) Then 0
+        If(length between(350, lowerBoundsToUpperBounds.get(350).get)) Then 350
+        If(length between(650, lowerBoundsToUpperBounds.get(650).get)) Then 650
+        If(length >= 900) Then 900)
 
     awaitWithTransformation(db.run(metricsTable
       .filter(Filters.originFilters)
-      .map( metric =>
-        Case
-          If(metric.commissionedWordCount between(0, lowerBoundsToUpperBounds.get(0).get)) Then 0
-          If(metric.commissionedWordCount between(350, lowerBoundsToUpperBounds.get(350).get)) Then 350
-          If(metric.commissionedWordCount between(650, lowerBoundsToUpperBounds.get(650).get)) Then 650
-          If(metric.commissionedWordCount >= 900) Then 900
-      )
+      .map( metric => if(groupByCommissionedLength) assignLowerBound(metric.commissionedWordCount) else assignLowerBound(metric.wordCount))
       .groupBy(identity)
       .map{case (lowerBound, metric) => (lowerBound, metric.size)}
       .result))(dbResult => {

--- a/app/models/db/DBResponses.scala
+++ b/app/models/db/DBResponses.scala
@@ -15,11 +15,11 @@ object ArticleWordCountResponseList {
   implicit val articleWordCountResponseListEncoder: Encoder[ArticleWordCountResponseList] = deriveEncoder[ArticleWordCountResponseList]
 }
 
-case class GroupedWordCount(countRange: (Int, Option[Int]), count: Int)
+case class ArticleLengthGroup(range: (Int, Option[Int]), count: Int)
 
-object GroupedWordCount {
-  implicit val groupedWordCountApiResponseEncoder: Encoder[GroupedWordCount] =
-    deriveEncoder[GroupedWordCount]
+object ArticleLengthGroup {
+  implicit val articleLengthGroupResponseEncoder: Encoder[ArticleLengthGroup] =
+    deriveEncoder[ArticleLengthGroup]
 }
 
 case class ForkResponse(issueDate: DateTime, timeToPublication: Int)

--- a/app/models/db/DBResponses.scala
+++ b/app/models/db/DBResponses.scala
@@ -44,3 +44,6 @@ object CountResponse {
   implicit val metricEncoder: Encoder[Metric] = deriveEncoder
 }
 
+sealed trait ArticleLength
+case object FinalLength extends ArticleLength
+case object CommissionedLength extends ArticleLength

--- a/conf/routes
+++ b/conf/routes
@@ -1,12 +1,13 @@
-GET     /                                 controllers.Application.index
+GET     /                                          controllers.Application.index
 
-GET     /api/originatingSystem/:system    controllers.Application.getStartedIn(system: String)
-GET     /api/commissioningDesks           controllers.Application.getCommissioningDeskList
-GET     /api/inWorkflow/:inWorkflow       controllers.Application.getWorkflowData(inWorkflow: Boolean)
-GET     /api/fork/*newspaperBook          controllers.Application.getForks(newspaperBook: String)
-GET     /api/newspaperBooks               controllers.Application.getNewspaperBookList
-GET     /api/wordCount/articles           controllers.Application.getArticlesWithWordCounts
-GET     /api/wordCount/groupedWordCounts  controllers.Application.getGroupedWordCounts
+GET     /api/originatingSystem/:system             controllers.Application.getStartedIn(system: String)
+GET     /api/commissioningDesks                    controllers.Application.getCommissioningDeskList
+GET     /api/inWorkflow/:inWorkflow                controllers.Application.getWorkflowData(inWorkflow: Boolean)
+GET     /api/fork/*newspaperBook                   controllers.Application.getForks(newspaperBook: String)
+GET     /api/newspaperBooks                        controllers.Application.getNewspaperBookList
+GET     /api/wordCount/articles                    controllers.Application.getArticlesWithWordCounts
+GET     /api/wordCount/grouped/articleLengths      controllers.Application.getGroupedArticleLengths
+GET     /api/wordCount/grouped/commissionedLengths controllers.Application.getGroupedCommissionedLengths
 
 # endpoints for posting data from other apps
 OPTIONS /api/metric/*url                  controllers.Application.allowCORSAccess(methods = "PUT, POST, DELETE", url: String)

--- a/conf/routes
+++ b/conf/routes
@@ -6,8 +6,8 @@ GET     /api/inWorkflow/:inWorkflow                controllers.Application.getWo
 GET     /api/fork/*newspaperBook                   controllers.Application.getForks(newspaperBook: String)
 GET     /api/newspaperBooks                        controllers.Application.getNewspaperBookList
 GET     /api/wordCount/articles                    controllers.Application.getArticlesWithWordCounts
-GET     /api/wordCount/grouped/articleLengths      controllers.Application.getGroupedArticleLengths
-GET     /api/wordCount/grouped/commissionedLengths controllers.Application.getGroupedCommissionedLengths
+GET     /api/wordCount/grouped/articleLengths      controllers.Application.getArticlesGroupedByLength
+GET     /api/wordCount/grouped/commissionedLengths controllers.Application.getArticlesGroupedByCommissionedLength
 
 # endpoints for posting data from other apps
 OPTIONS /api/metric/*url                  controllers.Application.allowCORSAccess(methods = "PUT, POST, DELETE", url: String)

--- a/conf/routes
+++ b/conf/routes
@@ -6,8 +6,8 @@ GET     /api/inWorkflow/:inWorkflow                controllers.Application.getWo
 GET     /api/fork/*newspaperBook                   controllers.Application.getForks(newspaperBook: String)
 GET     /api/newspaperBooks                        controllers.Application.getNewspaperBookList
 GET     /api/wordCount/articles                    controllers.Application.getArticlesWithWordCounts
-GET     /api/wordCount/grouped/articleLengths      controllers.Application.getArticlesGroupedByLength
-GET     /api/wordCount/grouped/commissionedLengths controllers.Application.getArticlesGroupedByCommissionedLength
+GET     /api/wordCount/grouped/finalLength         controllers.Application.getArticlesGroupedByFinalLength
+GET     /api/wordCount/grouped/commissionedLength  controllers.Application.getArticlesGroupedByCommissionedLength
 
 # endpoints for posting data from other apps
 OPTIONS /api/metric/*url                  controllers.Application.allowCORSAccess(methods = "PUT, POST, DELETE", url: String)


### PR DESCRIPTION
Adding an endpoint to return counts for commissioned length for each word count bound.

This is very similar logic to the endpoint for returning the grouped data for article lengths so some refactoring to reuse logic. 