### PR TITLE
Add ability to select single day

### DIFF
--- a/public/js/components/Charts/AreaChartWrap.js
+++ b/public/js/components/Charts/AreaChartWrap.js
@@ -1,38 +1,47 @@
 import React from 'react';
-import { AreaChart , Themes } from 'formidable-charts';
+import { AreaChart, BarChart, Themes } from 'formidable-charts';
 import ChartTheme from '../ChartTheme/theme';
 import ChartsToggles from '../ChartsToggles';
 import Chart from './Chart';
+import { dateCount, xDomain } from '../../helpers/chartsHelpers';
 
 const customisedTheme = Object.assign({}, Themes.simple, ChartTheme);
 
-const AreaChartWrap = ({ data, xLabel, yLabel, yLabelStacked, scale, isStacked, error, hasToggle, height, titleHeader, chartType, toggleStackChart, filterVals, hasCsvButton, isUpdating }) =>
-    <Chart error={error} isUpdating={isUpdating}>
-        {titleHeader}
-        <AreaChart
-            stacked={isStacked}
-            height={height}
-            theme={customisedTheme}
-            series={isStacked ? data.percent : data.absolute}
-            xAxis={{
-                label: xLabel,
-                scale
-            }}
-            yAxis={{
-                label: isStacked ? yLabelStacked : yLabel,
-                scale: 'linear',
-                tickFormat: (datum) => isStacked ? `${datum}%` : datum
-            }}
-        />
-        <ChartsToggles
-            filterVals={filterVals}
-            hasToggle={hasToggle}
-            chartType={chartType}
-            data={data}
-            isStacked={isStacked}
-            hasCsvButton={hasCsvButton}
-            toggleStackChart={toggleStackChart}
-        />
-    </Chart>;
+const AreaChartWrap = ({ data, xLabel, yLabel, yLabelStacked, scale, isStacked, error, hasToggle, height, titleHeader, chartType, toggleStackChart, filterVals, hasCsvButton, isUpdating }) => {
+    const series = isStacked ? data.percent : data.absolute;
+    const ChartComponent = dateCount(series) > 1 ? AreaChart : BarChart;
+    return (
+        <Chart error={error} isUpdating={isUpdating}>
+            {titleHeader}
+            <ChartComponent
+                stacked={isStacked}
+                height={height}
+                theme={customisedTheme}
+                series={isStacked ? data.percent : data.absolute}
+                xAxis={{
+                    label: xLabel,
+                    scale
+                }}
+                yAxis={{
+                    label: isStacked ? yLabelStacked : yLabel,
+                    scale: 'linear',
+                    tickFormat: (datum) => isStacked ? `${datum}%` : datum
+                }}
+                domain={{
+                    x: xDomain(series)
+                }}
+            />
+            <ChartsToggles
+                filterVals={filterVals}
+                hasToggle={hasToggle}
+                chartType={chartType}
+                data={data}
+                isStacked={isStacked}
+                hasCsvButton={hasCsvButton}
+                toggleStackChart={toggleStackChart}
+            />
+        </Chart>
+    );
+};
 
 export default AreaChartWrap;

--- a/public/js/components/Charts/OriginCharts.js
+++ b/public/js/components/Charts/OriginCharts.js
@@ -25,7 +25,7 @@ const OriginCharts = ({ charts, isUpdating, toggleStackChart, filterVals }) => {
                     toggleStackChart={toggleStackChart}
                     chartType={'ComposerVsIncopy'}
                     titleHeader={renderTitle('originatingSystem')}
-                    scale='time'
+                    scale={{ x: "time" }}
                     data={charts.composerVsInCopy.data}
                     isStacked={charts.composerVsInCopy.isStacked}
                     error={charts.composerVsInCopy.error}

--- a/public/js/components/Charts/ScatterChartWrap.js
+++ b/public/js/components/Charts/ScatterChartWrap.js
@@ -1,9 +1,9 @@
-
 import React from 'react';
 import { ScatterChart , Themes } from 'formidable-charts';
 import ChartTheme from '../ChartTheme/theme';
 import ChartsToggles  from '../ChartsToggles';
 import Chart from './Chart';
+import { xDomain } from '../../helpers/chartsHelpers';
 
 const customisedTheme = Object.assign({}, Themes.simple, ChartTheme);
 
@@ -24,6 +24,9 @@ const ScatterChartWrap = ({ scale, error, noDataMessage, height, titleHeader, yL
                     yAxis={{
                         label: yLabel,
                         tickFormat: (datum) => `${datum}h`
+                    }}
+                    domain={{
+                        x: xDomain(data.absolute)
                     }}
                 />
                 <ChartsToggles

--- a/public/js/components/Filters/Filters.js
+++ b/public/js/components/Filters/Filters.js
@@ -69,6 +69,7 @@ export default class Filters extends Component {
                                             initialVisibleMonth={() => moment().subtract(1, 'months')}
                                             orientation={window.innerWidth > 640 ? 'horizontal' : 'vertical'}
                                             displayFormat='DD/MM/YYYY'
+                                            minimumNights={0}
                                             disabled={isUpdating || filterStatuses.startDate === "disabled" && filterStatuses.endDate === "disabled"}
                                             startDate={this.state.startDate}
                                             endDate={this.state.endDate}

--- a/public/js/helpers/chartsHelpers.js
+++ b/public/js/helpers/chartsHelpers.js
@@ -158,3 +158,28 @@ export {
     tagToName,
     getComparisonTimeSeriesFromResponses
 };
+
+export const uniqDates = series => [
+    ...new Set(
+        series.reduce(
+            (out, { data }) => [...out, ...data.map(({ x }) => x)],
+            []
+        )
+    )
+];
+
+export const xDomain = series => {
+    const dates = uniqDates(series);
+    if (!dates.length) {
+        const now = Date.now();
+        return [now, now];
+    } else if (dates.length > 1) {
+        return [Math.min(...dates), Math.max(...dates)];
+    }
+    const dayBefore = moment(dates[0]).subtract(1, "days").valueOf();
+    const dayAfter = moment(dates[0]).add(1, "days").valueOf();
+
+    return [dayBefore, dayAfter];
+};
+
+export const dateCount = series => new Set(uniqDates(series)).size;

--- a/public/js/selectors/charts.js
+++ b/public/js/selectors/charts.js
@@ -121,7 +121,7 @@ const createForkTimeData = chart => {
                 const date = moment(dataPoint['issueDate']).utc();
                 const hours = dataPoint.timeToPublication / 3600 / 1000;
                 return {
-                    x: date,
+                    x: date.valueOf(),
                     y: hours,
                     label: `${hours.toFixed(1)} hours`,
                     size: 2.5


### PR DESCRIPTION
This also include a fix to change `AreaChart` to `BarChart` if the date domain is only one date wide. There is also a hack to centre single dates along the x axis: ideally we'd use the `domainPadding` prop but `formidable-charts` includes an old version of `victory-charts` where this was broken for series with only one unique value in the x-axis ☹️ 

This also fixes empty charts starting at 1970 all the time!