### PR TITLE
Exclude fork data points over 24 hours

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -86,7 +86,7 @@ class Application(implicit val wsClient: WSClient, val db: MetricsDB) extends Co
 
   def getForks(newspaperBook: String) = APIAuthAction { req =>
     APIResponse {
-      db.getForks(Filters(req.queryString).copy(newspaperBook = Some(newspaperBook)).copy(maxForkTimeInMilliseconds = Some(86400000)))
+      db.getForks(Filters(req.queryString).copy(newspaperBook = Some(newspaperBook)))
     }
   }
 

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -86,7 +86,7 @@ class Application(implicit val wsClient: WSClient, val db: MetricsDB) extends Co
 
   def getForks(newspaperBook: String) = APIAuthAction { req =>
     APIResponse {
-      db.getForks(Filters(req.queryString).copy(newspaperBook = Some(newspaperBook)))
+      db.getForks(Filters(req.queryString).copy(newspaperBook = Some(newspaperBook)).copy(maxForkTimeInMilliseconds = Some(86400000)))
     }
   }
 

--- a/app/models/db/Filters.scala
+++ b/app/models/db/Filters.scala
@@ -19,11 +19,13 @@ case class Filters(
   productionOffice: Option[ProductionOffice] = None,
   inWorkflow: Option[Boolean] = None,
   newspaperBook: Option[String] = None,
-  hasCommissionedLength: Option[Boolean] = None
+  hasCommissionedLength: Option[Boolean] = None,
+  maxForkTimeInMilliseconds: Option[Int] = None
 )
 
 object Filters {
 
+  //Represents composer id, time to publication and time of fork
   type ForkFilterColumns = (Rep[String], Rep[Option[Int]], Rep[DateTime])
 
   private val TrueOptCol: Rep[Option[Boolean]] = LiteralColumn(Some(true))
@@ -87,6 +89,7 @@ object Filters {
     val (fork, metric) = data
     filters.dateRange.fold(TrueOptCol)(dr => fork._3.? >= dr.from && fork._3.? <= dr.to) &&
       filters.newspaperBook.fold(TrueOptCol)(nb => metric.newspaperBook.toLowerCase === nb.toLowerCase) &&
+      filters.maxForkTimeInMilliseconds.fold(TrueOptCol)(timeToPublication => fork._2 <= timeToPublication) &&
       commonFilters(metric)
   }
 

--- a/public/js/reducers/filtersReducer.js
+++ b/public/js/reducers/filtersReducer.js
@@ -7,7 +7,9 @@ const values = {
     newspaperBook: 'theguardian/mainsection', // TODO: set this programatically
     productionOffice: 'all',
     startDate: getYesterday().startOf('day').subtract(7,'d').format(),
-    endDate: getYesterday().endOf('day').format()
+    endDate: getYesterday().endOf('day').format(),
+    //This is set by default to 24 hours (86400000 milliseconds)
+    maxForkTimeInMilliseconds: 86400000
 };
 
 const activateAll = filters =>

--- a/public/js/services/Api.js
+++ b/public/js/services/Api.js
@@ -1,26 +1,27 @@
 import axios from 'axios';
 import { pandaFetch } from './pandaFetch';
 
-const buildQueryParams = (startDate, endDate, desk, productionOffice) => ({
+const buildQueryParams = ({startDate, endDate, desk, productionOffice, maxForkTimeInMilliseconds}) => ({
     params: {
         startDate: startDate,
         endDate: endDate,
         desk: desk !== 'tracking/commissioningdesk/all' && desk || null,
-        productionOffice: productionOffice !== 'all' && productionOffice || null
+        productionOffice: productionOffice !== 'all' && productionOffice || null,
+        maxForkTimeInMilliseconds: maxForkTimeInMilliseconds
     }
 });
 
 const getOriginatingSystem = (system, startDate, endDate, desk, productionOffice) => 
-    pandaFetch(`api/originatingSystem/${system}`, buildQueryParams(startDate, endDate, desk, productionOffice));
+    pandaFetch(`api/originatingSystem/${system}`, buildQueryParams({startDate, endDate, desk, productionOffice}));
 
 const getWorkflowCount = (isInWorkflow, startDate, endDate, desk, productionOffice) =>
-    pandaFetch(`api/inWorkflow/${isInWorkflow}`, buildQueryParams(startDate, endDate, desk, productionOffice));
+    pandaFetch(`api/inWorkflow/${isInWorkflow}`, buildQueryParams({startDate, endDate, desk, productionOffice}));
 
 const getCommissioningDesks = () => pandaFetch('api/commissioningDesks', null);
 
 const getNewspaperBooks = () => pandaFetch('api/newspaperBooks', null);
 
-const getForkTime = (startDate, endDate, newspaperBook) => pandaFetch(`api/fork/${newspaperBook}`, buildQueryParams(startDate, endDate));
+const getForkTime = (startDate, endDate, newspaperBook, maxForkTimeInMilliseconds) => pandaFetch(`api/fork/${newspaperBook}`, buildQueryParams({startDate, endDate, maxForkTimeInMilliseconds}));
 
 const getComposerVsIncopy = (startDate, endDate, desk, productionOffice) =>
     axios.all([
@@ -45,19 +46,19 @@ const getInWorkflowVsNotInWorkflow = (startDate, endDate, desk, productionOffice
 const getWordCount = (startDate, endDate, desk, productionOffice) =>
     pandaFetch(
         "api/wordCount/grouped/finalLength",
-        buildQueryParams(startDate, endDate, desk, productionOffice)
+        buildQueryParams({startDate, endDate, desk, productionOffice})
     );
 
-const getCommissionedLength = (startDate, endDate, desk, productionOffice) =>
+const getCommissionedLength = ({startDate, endDate, desk, productionOffice}) =>
     pandaFetch(
         "api/wordCount/grouped/commissionedLength",
-        buildQueryParams(startDate, endDate, desk, productionOffice)
+        buildQueryParams({startDate, endDate, desk, productionOffice})
     );
 
-const getWordCountArticles = (startDate, endDate, desk, productionOffice) =>
+const getWordCountArticles = ({startDate, endDate, desk, productionOffice}) =>
     pandaFetch(
         "api/wordCount/articles",
-        buildQueryParams(startDate, endDate, desk, productionOffice)
+        buildQueryParams({startDate, endDate, desk, productionOffice})
     );
 
 export default {

--- a/public/js/utils/chartList.js
+++ b/public/js/utils/chartList.js
@@ -1,7 +1,7 @@
 export const CHART_FILTERS_MAP = {
   "InWorkflowVsNotInWorkflow": ["startDate", "endDate", "desk", "productionOffice"],
   "ComposerVsIncopy": ["startDate", "endDate", "desk", "productionOffice"],
-  "ForkTime": ["startDate", "endDate", "newspaperBook"],
+  "ForkTime": ["startDate", "endDate", "newspaperBook", "maxForkTimeInMilliseconds"],
   "WordCount": ["startDate", "endDate", "desk", "productionOffice"],
   "CommissionedLength": ["startDate", "endDate", "desk", "productionOffice"],
   "WordCountArticles": ["startDate", "endDate", "desk", "productionOffice"],


### PR DESCRIPTION
Outliers in the fork data are stopping the fork time graph from being useful 
![screen shot 2018-04-11 at 10 45 07](https://user-images.githubusercontent.com/6666113/38609231-759ac70e-3d75-11e8-972f-7f28e6a82794.jpg)
Editorial are not interested in content published more than 24 hours after forking as they are one offs and make the graph less readable. Added the ability to fliter the graph by 'maxForkTimeInMilliseconds` and hard coded it to be 24 hours for now
![screen shot 2018-04-11 at 10 47 28](https://user-images.githubusercontent.com/6666113/38609364-c629ea4c-3d75-11e8-83ca-89db91730079.jpg)
More readable