### PR TITLE
Use docker-compose for tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -86,19 +86,10 @@ resourceDirectory in IntegrationTests := baseDirectory.value / "/test-integratio
 scalaSource in IntegrationTests := baseDirectory.value / "/test-integration"
 
 testOptions in IntegrationTests += Tests.Setup(_ => {
-  val dbUser = "postgres"
-  val dbPassword = "postgres"
-  val dbName = "default"
-  val dbPort = 5903
+  println(s"Launching docker container with PostgreSQL")
+  s"docker-compose up -d".!
 
-  ("docker rm -fv metricsdb-postgres" #|| "true").!
-  println(s"Launching docker postgres image on port $dbPort")
-  s"docker run --name metricsdb-postgres -e POSTGRES_USER=$dbUser -e POSTGRES_PASSWORD=$dbPassword -e POSTGRES_DB=$dbName -p $dbPort:5432 -d postgres:9.4-alpine".!
-
-  println("Waiting for Postgres to startup...")
-  while("docker exec metricsdb-postgres pg_isready".! > 0) {
-    Thread.sleep(1000)
-  }
+  // This is needed to ensure docker has had enough time to start up
   Thread.sleep(5000)
 })
 

--- a/test-integration/controllers/MetricsDBSpec.scala
+++ b/test-integration/controllers/MetricsDBSpec.scala
@@ -1,10 +1,10 @@
 package controllers
 
-import com.gu.editorialproductionmetricsmodels.models.{MetricOpt, ProductionOffice}
+import com.gu.editorialproductionmetricsmodels.models.MetricOpt
 import database.MetricsDB
 import helpers.{PostgresHelpers, TestData}
 import models.ProductionMetricsError
-import models.db.{ForkResponse, Metric, Filters}
+import models.db.{Filters, ForkResponse, Metric}
 import org.joda.time.DateTime
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSuite, Matchers}

--- a/test-integration/helpers/PostgresHelpers.scala
+++ b/test-integration/helpers/PostgresHelpers.scala
@@ -21,7 +21,7 @@ trait PostgresHelpers extends Suite with BeforeAndAfterAll with BeforeAndAfterEa
   private[this] val database = Databases(
     driver = "org.postgresql.Driver",
     url = s"jdbc:postgresql://localhost:5902/$testDbName",
-    name = testDbName,
+    name = "default",
     config = Map(
       "user" -> testDbUser,
       "password" -> testDbPassword
@@ -30,6 +30,8 @@ trait PostgresHelpers extends Suite with BeforeAndAfterAll with BeforeAndAfterEa
   implicit lazy val db: Database = Database.forURL(setupJdbcUrl, driver = driver, user = testDbUser, password = testDbPassword)
 
   override def beforeAll() {
+    Evolutions.applyEvolutions(database)
+
     await(db.run(DBIO.seq(
       sqlu"DROP DATABASE IF EXISTS #$testDbName",
       sqlu"CREATE DATABASE #$testDbName")))

--- a/test-integration/helpers/PostgresHelpers.scala
+++ b/test-integration/helpers/PostgresHelpers.scala
@@ -13,18 +13,18 @@ trait PostgresHelpers extends Suite with BeforeAndAfterAll with BeforeAndAfterEa
   TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
 
   private[this] val driver = "slick.jdbc.PostgresProfile"
-  private[this] val testDbName = "default"
-  private[this] val setupJdbcUrl = s"jdbc:postgresql://localhost:5903/$testDbName"
-  private[this] val testDbUser = "postgres"
-  private[this] val testDbPassword = "postgres"
+  private[this] val testDbName = "metrics"
+  private[this] val setupJdbcUrl = s"jdbc:postgresql://localhost:5902/$testDbName"
+  private[this] val testDbUser = "metrics"
+  private[this] val testDbPassword = "metrics"
   //This is needed for applying evolutions.
   private[this] val database = Databases(
     driver = "org.postgresql.Driver",
-    url = s"jdbc:postgresql://localhost:5903/$testDbName",
+    url = s"jdbc:postgresql://localhost:5902/$testDbName",
     name = testDbName,
     config = Map(
-      "user" -> "postgres",
-      "password" -> "postgres"
+      "user" -> testDbUser,
+      "password" -> testDbPassword
     )
   )
   implicit lazy val db: Database = Database.forURL(setupJdbcUrl, driver = driver, user = testDbUser, password = testDbPassword)


### PR DESCRIPTION
Now that TeamCity supports `docker-compose` we can use reuse the setup for running locally.