### PR TITLE
Take extract text plugin off `beta`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "eslint": "^4.15.0",
     "eslint-loader": "^1.9.0",
     "eslint-plugin-react": "^7.5.1",
-    "extract-text-webpack-plugin": "beta",
+    "extract-text-webpack-plugin": "^2.0.0",
     "file-loader": "^0.9.0",
     "jest": "^22.0.6",
     "node-sass": "3.8.0",


### PR DESCRIPTION
Take extract text plugin off `beta` as there is a new beta out and it does not support webpack 2