### PR TITLE
Add the Ed Tools shadowing page

### DIFF
--- a/public/js/components/Tabs/EditorialShadowing.js
+++ b/public/js/components/Tabs/EditorialShadowing.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Row, Col } from 'react-flexbox-grid';
+
+const devs = [];
+const shadowers = [];
+
+const VerticalPadding = ({ children }) => (
+  <div style={{ padding: '20px 0' }}>{children}</div>
+);
+
+const Heading = ({ children }) => (
+  <div>
+    <h2 style={{ display: 'inline-block', borderBottom: '1px solid #ffbc01' }}>
+      {children}
+    </h2>
+  </div>
+);
+
+const List = ({ items }) => <ul>{items.map(item => <li>{item}</li>)}</ul>;
+
+const NameList = ({ title, names }) => (
+  <VerticalPadding>
+    <Heading>{title}</Heading>
+    {names.length ? <List items={names} /> : 'No people here :('}
+  </VerticalPadding>
+);
+
+const EditorialShadowing = () => {
+  return (
+    <Row around="xs">
+      <Col xs={12} md={8}>
+        <VerticalPadding>
+          This is a list of the names (or pseudonyms if you're not comfortable
+          adding your name!) of the people who have shadowed the editorial tools
+          team and the developers that worked with them. Part of the shadowing
+          process will be adding your name to this list.
+          <NameList title="People" names={shadowers} />
+          <NameList title="Developers" names={devs} />
+        </VerticalPadding>
+      </Col>
+    </Row>
+  );
+};
+
+export default EditorialShadowing;

--- a/public/js/containers/App.js
+++ b/public/js/containers/App.js
@@ -16,6 +16,7 @@ import {
     TabsNav,
     TabsContainer
 } from "../components/Tabs";
+import EditorialShadowing from "../components/Tabs/EditorialShadowing";
 import { Route, Redirect } from "react-router-dom";
 
 class App extends Component {
@@ -53,6 +54,9 @@ class App extends Component {
                         <TabLink to="/commissioned-length">
                             Commissioned Length
                         </TabLink>
+                        <TabLink to="/editorial-shadowing">
+                            Editorial shadowing
+                        </TabLink>
                     </TabsNav>
                     <TabsPanel>
                         <Route exact path="/" render={() => <Redirect to="/origin"/>}/>
@@ -70,6 +74,9 @@ class App extends Component {
                         </TabRoute>
                         <TabRoute path="/commissioned-length">
                             <CommissionedLengthData />
+                        </TabRoute>
+                        <TabRoute path="/editorial-shadowing">
+                            <EditorialShadowing />
                         </TabRoute>
                     </TabsPanel>
                 </TabsContainer>


### PR DESCRIPTION
This adds a page that will be used to show people the process of a code change in ed tools (change / branch / PR / deploy etc.). The assumption is that people (both developers and shadowers) will add themselves to the relevant arrays in `/public/js/components/Tabs/EditorialShadowing.js` and then follow the usual deploy process from there 👍 