### PR TITLE
Use ssm for tunnelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A tool for recording and displaying metrics on how editorial content is produced
 You'll need:
  * [AWS CLI](http://docs.aws.amazon.com/cli/latest/userguide/installing.html) installed. Version `1.11.190` or later.
  * Credentials for the composer AWS account from [janus](https://janus.gutools.co.uk).
+ * [ssm-scala](https://github.com/guardian/ssm-scala) installed. `brew install guardian/devtools/ssm` to install with Homebrew
  * Set up SSL certificates by following the 'Install SSL certificates' step in the [dev-nginx readme](https://github.com/guardian/dev-nginx)
  * Set up config locally using [this guide](#local-config)
  * Setup the nginx mapping by following the instructions in the [dev-nginx readme](https://github.com/guardian/dev-nginx#install-config-for-an-application).

--- a/setup-ssh-tunnel.sh
+++ b/setup-ssh-tunnel.sh
@@ -41,6 +41,4 @@ fi
 DATASTORE_HOST=$(prism stage=CODE stack=flexible app=editorial-production-metrics -f instanceName | awk '{print $4}' | head -1)
 echo $DATASTORE_HOST
 
-CONNECTION=$(ssm ssh --profile composer -i ${DATASTORE_HOST} --private --raw)
-
-${CONNECTION} -f -N -L 5902:${RDSHOST}:5432
+$(ssm ssh --profile composer -i ${DATASTORE_HOST} --private --raw) -f -N -L 5902:${RDSHOST}:5432

--- a/setup-ssh-tunnel.sh
+++ b/setup-ssh-tunnel.sh
@@ -38,8 +38,9 @@ if [ -z "${RDSHOST}" ]; then
     exit 1
 fi
 
-
-DATASTORE_HOST=$(marauder -s stage=CODE app=editorial-production-metrics --short)
+DATASTORE_HOST=$(prism stage=CODE stack=flexible app=editorial-production-metrics -f instanceName | awk '{print $4}' | head -1)
 echo $DATASTORE_HOST
 
-ssh -f ubuntu@${DATASTORE_HOST} -L 5902:${RDSHOST}:5432 -N
+CONNECTION=$(ssm ssh --profile composer -i ${DATASTORE_HOST} --private --raw)
+
+${CONNECTION} -f -N -L 5902:${RDSHOST}:5432


### PR DESCRIPTION
Updated tunnelling script to use ssm.

A quick fix but I think it's worth considering at some point:
1. Using docker so that there is no longer any need to tunnel. There would also need to be a script to populate the db
2. Adding port forwarding to ssm-scala