### PR TITLE
Upversion the AWS SDK to support IMDSv2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ scalacOptions ++= Seq(
   "-deprecation",
   "-Ywarn-unused-import")
 
-lazy val awsVersion = "1.11.77"
+lazy val awsVersion = "1.11.678"
 
 val databaseDependencies = Seq(
   ws,


### PR DESCRIPTION
## What does this change?

Upversions the AWS SDK to enable the use of [IMDSv2](https://github.com/guardian/security-hq/blob/main/hq/markdown/guardduty-sechub-common-problems.md). Thought this wasn't needed, turns out 77 < 678.

## How to test

When deployed with the [infra changes](https://github.com/guardian/editorial-tools-platform/pull/535), the app should work as before, and IMDSv1 usage should stop.


