### PR TITLE
Fix json parsing

### DIFF
--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -36,7 +36,7 @@ object Config extends AwsInstanceTags {
 
   val publishingMetricsKinesisStream: String = config.getString("kinesis.publishingMetricsStream")
 
-  val tagManagerUrl = s"${getPropertyWithDefault("tagManager.url", config.getString, default = "http:tagmanager.gutools.co.uk")}/hyper/tags"
+  val tagManagerUrl = s"${getPropertyWithDefault("tagManager.url", config.getString, default = "http://tagmanager.gutools.co.uk")}/hyper/tags"
 
 //  This is for uniquely identifying the kinesis application when running the app locally on multiple DEV machines
   val devIdentifier: String = if(stage == "DEV") config.getString("user") else ""

--- a/app/services/EC2Client.scala
+++ b/app/services/EC2Client.scala
@@ -5,7 +5,7 @@ import com.amazonaws.services.ec2.AmazonEC2ClientBuilder
 import com.amazonaws.services.ec2.model.{DescribeTagsRequest, Filter}
 import com.amazonaws.util.EC2MetadataUtils
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 
 object EC2Client {
@@ -26,7 +26,7 @@ trait AwsInstanceTags {
           new Filter("key").withValues(tagName)
         )
       )
-      tagsResult.getTags.find(_.getKey == tagName).map(_.getValue)
+      tagsResult.getTags.asScala.find(_.getKey == tagName).map(_.getValue)
     }
   }
 }

--- a/app/util/Parser.scala
+++ b/app/util/Parser.scala
@@ -47,10 +47,4 @@ object Parser {
   def jsonToCapiData(json: Json): Either[ProductionMetricsError, CapiData] =
     json.as[CapiData].fold(processException, Right(_))
 
-  def extractFromString[A](str: String)(implicit decoder: Decoder[A]): Either[ProductionMetricsError, A] =
-    for {
-      json <- stringToJson(str)
-      result <- json.as[A].fold(processException, m => Right(m))
-    } yield result
-
 }

--- a/app/util/Parser.scala
+++ b/app/util/Parser.scala
@@ -3,7 +3,7 @@ package util
 import com.gu.editorialproductionmetricsmodels.models.MetricOpt._
 import com.gu.editorialproductionmetricsmodels.models.{CapiData, KinesisEvent, MetricOpt}
 import io.circe.generic.auto._
-import io.circe.{Decoder, Json, parser}
+import io.circe.{Json, parser}
 import models.db.Metric
 import models.db.Metric._
 import models.{CommissioningDesks, ProductionMetricsError}

--- a/build.sbt
+++ b/build.sbt
@@ -24,8 +24,8 @@ val databaseDependencies = Seq(
 lazy val sharedDependencies = Seq(
   "com.amazonaws"          % "aws-java-sdk-core"                 % awsVersion,
   "com.amazonaws"          % "amazon-kinesis-client"             % "1.7.6",
-  "io.circe"               %% "circe-parser"                     % "0.8.0",
-  "io.circe"               %% "circe-generic"                    % "0.8.0",
+  "io.circe"               %% "circe-parser"                     % "0.11.0",
+  "io.circe"               %% "circe-generic"                    % "0.11.0",
   "com.beachape"           %% "enumeratum-circe"                 % "1.5.14",
   "com.gu"                 %% "editorial-production-metrics-lib" % "0.18"
 )
@@ -34,6 +34,7 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala, RiffRaffArtifact
   .settings(Defaults.coreDefaultSettings: _*)
   .settings(
     libraryDependencies ++= Seq(
+      "com.dripower"           %% "play-circe"                   % "2611.0",
       "ch.qos.logback"         % "logback-core"                  % "1.2.7",
       "ch.qos.logback"         % "logback-classic"               % "1.2.7",
       "com.amazonaws"          % "aws-java-sdk-ec2"              % awsVersion,

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -2,11 +2,11 @@
     <contextName>editorial-production-metrics</contextName>
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${application.home}/logs/application.log</file>
+        <file>${application.home:-.}/logs/application.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
             <fileNamePattern>
-                ${application.home}/logs/application.log.%i
+                ${application.home:-.}/logs/application.log.%i
             </fileNamePattern>
             <minIndex>1</minIndex>
             <maxIndex>30</maxIndex>


### PR DESCRIPTION
## What does this change?

Use play-circe instead of custom parse wiring.  This fixes a bug introduced as part of the Play 2.6 upgrade.  `parse.text` expects the `Content-type` to be `text/plain` which is not what workflow is sending.  A simpler fix would be to change to `parse.tolerantText` but I think using play-circe is neater.  This follows the same pattern as other projects (e.g. payments API). 

This older play-circe version was selected because it depends on the same circe version as this project.

This PR has a fewer minor changes
- fixes typo in URL from upgrade
- explicitly uses circe-parser v0.11.0 (previously SBT was selecting this version anyway)
- fixes logging
- resolves a deprecation warning (JavaConversions)

## How to test

I've tried to test in CODE, by creating an article in Workflow and then publishing it.  The JSON metric is parsed correctly, but there was a db error ("duplicate key value violates unique constraint "metrics_composer_id_key"). I don't think this is related to this change.

## How can we measure success?

https://productionmetrics.gutools.co.uk/origin shows some content seen in workflow.

## Have we considered potential risks?

Metrics aren't currently being tracked, I don't think this PR can make things any worse
