### PR TITLE
Build should fail if any step fails

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 echo "##teamcity[compilationStarted compiler='yarn']"
 npm install --global yarn
 yarn install


### PR DESCRIPTION
## What does this change?

ci build should fail if any steps fail. At the moment the build will always appear to succeed because the last step in the script is an `echo`. `set -e` will stop the script and return the error code if any command fails.